### PR TITLE
Follow up commits on Ninvalidation

### DIFF
--- a/app/src/main/java/com/jnj/vaccinetracker/common/validators/NinValidator.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/common/validators/NinValidator.kt
@@ -5,10 +5,11 @@ import javax.inject.Inject
 class NinValidator @Inject constructor() {
 
     companion object {
-        /**
+         /**
          * The regex ^[A-Z0-9]{14}$ matches exactly 14 alphanumeric characters (letters or digits)
          * with case insensitivity due to RegexOption.IGNORE_CASE 
-         */       
+         * This regex will now allow  both CM00000000FFKH and CM00000000FF6H, 
+         */        
         private val NIN_REGEX = Regex("^[A-Z0-9]{14}$", RegexOption.IGNORE_CASE)
     }
 


### PR DESCRIPTION
Follow up commit https://github.com/ConnectForLife/vxnaid/pull/30

Tested and comfirm from two National indentification Number and following this guideline from [Uganda](https://docs.usesmileid.com/supported-id-types/for-individuals-kyc/backed-by-id-authority/supported-countries/uganda/national-id-without-photo)   cc @druchniewicz 