### PR TITLE
Migrate to ksp

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
+apply plugin: 'com.google.devtools.ksp'
 apply plugin: 'org.jetbrains.kotlin.plugin.parcelize'
 apply plugin: 'io.gitlab.arturbosch.detekt'
 apply plugin: 'org.jetbrains.dokka'
@@ -25,11 +26,11 @@ android {
         applicationId "com.jnj.vaccinetracker"
         minSdkVersion config.buildConfig.minSdkVersion
         targetSdkVersion config.buildConfig.targetSdkVersion
+        ksp {
+            arg("room.schemaLocation", "$projectDir/schemas")
+            arg("room.incremental", "true")
+        }
         kapt {
-            arguments {
-                arg("room.schemaLocation", "$projectDir/schemas".toString())
-                arg("room.incremental", "true")
-            }
             correctErrorTypes = true
             useBuildCache = true
         }
@@ -121,8 +122,8 @@ android {
             manifest.srcFile 'src/debug/AndroidManifest.xml'
         }
         androidTest.java.srcDirs += 'src/androidTest/kotlin'
-        androidTest.java.srcDirs += [file("$buildDir/generated/source/kapt/androidTest")]
-        androidTest.java.srcDirs += [file("$buildDir/generated/source/kaptKotlin/androidTest")]
+        androidTest.java.srcDirs += [file("$buildDir/generated/source/ksp/androidTest")]
+        androidTest.java.srcDirs += [file("$buildDir/generated/source/kspKotlin/androidTest")]
     }
 }
 
@@ -154,11 +155,11 @@ dependencies {
     }
 
     deps.annotationProcessors.each { name, dep ->
-        kapt dep
+        ksp dep
     }
 
     deps.androidTestAnnotationProcessors.each { name, dep ->
-        kaptAndroidTest dep
+        kspAndroidTest dep
     }
 
     deps.testImplementation.each { name, dep ->

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,10 @@ buildscript {
     }
 }
 
+plugins {
+    id("com.google.devtools.ksp") version "2.0.21-1.0.25" apply false
+}
+
 allprojects {
     repositories {
         google()

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 def versions = [
         buildtools       : '8.5.0',
-        kotlin           : '2.0.0',
+        kotlin           : '2.0.21',
         detekt           : '1.20.0-RC1',
         fragmentKtx      : '1.2.5',
         activityKtx      : '1.1.0',


### PR DESCRIPTION
We need to migrate to KSP for correct class generation. Refer to the migration guide: https://developer.android.com/build/migrate-to-ksp. However, we can't completely remove KAPT as it's still required for data binding.