### PR TITLE
child_number mandatory with (*)

### DIFF
--- a/app/src/main/res/layout/fragment_register_participant_participant_details.xml
+++ b/app/src/main/res/layout/fragment_register_participant_participant_details.xml
@@ -137,13 +137,25 @@
                 android:gravity="center_vertical"
                 android:orientation="horizontal">
 
-                <TextView
-                    android:id="@+id/textView_participant_registration_details_label_child_number"
+                <LinearLayout
                     android:layout_width="155dp"
-                    android:layout_height="wrap_content"
-                    android:maxLines="2"
-                    android:text="@string/participant_flow_child_number_title"
-                    android:textAppearance="@style/LabelText" />
+                    android:layout_height="wrap_content">
+
+                    <TextView
+                        android:id="@+id/textView_participant_registration_details_label_child_number"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:maxLines="2"
+                        android:text="@string/participant_flow_child_number_title"
+                        android:textAppearance="@style/LabelText" />
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/participant_registration_add_asterisk"
+                        android:textColor="@android:color/holo_red_dark"
+                        android:textSize="18sp"
+                        android:layout_marginStart="2dp" />
+                </LinearLayout>
 
                 <EditText
                     android:id="@+id/editText_child_number"
@@ -207,6 +219,7 @@
                         android:maxLines="2"
                         android:text="@string/participant_registration_details_label_child_name"
                         android:textAppearance="@style/LabelText" />
+
                 </LinearLayout>
 
                 <EditText


### PR DESCRIPTION
In this pull request, we are fixing an issue on jira named VRVU-261.
https://sd-vxnaid.atlassian.net/browse/VRVU-261 

1. Basically what we have done is to add an asterisk(*) to the label of "Child Number" in the fragment_register_participant_participant_details.xml file.
2. The changes are between line 140 and line 158
3. We added a textview for the asterisk(*)
4. We added a linear layout and put the two textviews inside it.
5. We then adjusted the layout_width and layout_height for the textview for child number to "wrap_content" and also adjusted the ones for the linear layout to 155dp and wrap_content respectively.
![child number](https://github.com/user-attachments/assets/3ad83952-7835-440d-ac29-a0bbf4cb6fda)
