### PR TITLE
Support 64 bit compliance and versionCodes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,8 +34,8 @@ android {
             correctErrorTypes = true
             useBuildCache = true
         }
-        versionCode generateVersionCode()
-        versionName generateVersionName()
+        versionCode = 1
+        versionName = "1.0"
         setProperty("archivesBaseName", "VMP-$versionName")
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -64,12 +64,14 @@ android {
             //proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.release
             ndk {
-                abiFilters 'armeabi-v7a'
+                //abiFilters 'armeabi-v7a'
+                abiFilters "armeabi-v7a","arm64-v8a","x86","x86_64"
             }
         }
         debug {
             ndk {
-                abiFilters 'x86', 'armeabi-v7a'
+               // abiFilters 'x86', 'armeabi-v7a'
+                abiFilters "armeabi-v7a","arm64-v8a","x86","x86_64"
             }
             versionNameSuffix "-debug"
             debuggable true


### PR DESCRIPTION
Ticket Number  https://sd-vxnaid.atlassian.net/browse/VRVU-264   cc @druchniewicz 

**Google playstore 64 bit compliance:** 
We added this line in build.gradle (:app) and commented the original one:
- abiFilters "armeabi-v7a","arm64-v8a","x86","x86_64"

**Version Codes were throwing an error on upload on playstore:**
We replace the function calls such as generateVersionCode() and generateVersionName(), with simple version code numbers like 1 and version name "1.0"

