### PR TITLE
Adding A Historical Visits MUST Not Allow Use Of Today's Date or a fu…

### DIFF
--- a/app/src/main/java/com/jnj/vaccinetracker/common/data/models/Constants.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/common/data/models/Constants.kt
@@ -103,7 +103,7 @@ object Constants {
     const val CHILD_CATEGORY_REFUGEE = "Refugee"
 
     const val VISITS_OVERVIEW_SCHEDULED_VISITS_KEY = "Scheduled Visits"
-    const val VISITS_OVERVIEW_HISTORICAL_VISITS_KEY = "Historical Visits"
+    const val VISITS_OVERVIEW_HISTORICAL_VISITS_KEY = "Visit History"
     const val VISITS_OVERVIEW_MISSED_VISITS_KEY = "Missed Visits"
 
     const val VISIT_DATE_FILE_COLUMN_HEADER = "Visit Date"

--- a/app/src/main/java/com/jnj/vaccinetracker/register/dialogs/HistoricalVisitDateDialog.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/register/dialogs/HistoricalVisitDateDialog.kt
@@ -75,12 +75,6 @@ class HistoricalVisitDateDialog() : BaseDialogFragment() {
       val calendar = Calendar.getInstance()
       calendar.add(Calendar.DAY_OF_YEAR, -1)
       datePicker.maxDate = calendar.timeInMillis
-      //  historical visits are restricted to dates strictly before today.
-      datePicker.updateDate(
-         calendar.get(Calendar.YEAR),
-         calendar.get(Calendar.MONTH),
-         calendar.get(Calendar.DAY_OF_MONTH)
-      )
 
       birthDate?.let {
          try {

--- a/app/src/main/java/com/jnj/vaccinetracker/register/dialogs/HistoricalVisitDateDialog.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/register/dialogs/HistoricalVisitDateDialog.kt
@@ -72,8 +72,16 @@ class HistoricalVisitDateDialog() : BaseDialogFragment() {
    }
 
    private fun setupDatePicker() {
-      val c = Calendar.getInstance()
-      datePicker.maxDate = c.timeInMillis
+      val calendar = Calendar.getInstance()
+      calendar.add(Calendar.DAY_OF_YEAR, -1)
+      datePicker.maxDate = calendar.timeInMillis
+      //  historical visits are restricted to dates strictly before today.
+      datePicker.updateDate(
+         calendar.get(Calendar.YEAR),
+         calendar.get(Calendar.MONTH),
+         calendar.get(Calendar.DAY_OF_MONTH)
+      )
+
       birthDate?.let {
          try {
             val sdf = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())

--- a/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantParticipantDetailsViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantParticipantDetailsViewModel.kt
@@ -738,6 +738,19 @@ class RegisterParticipantParticipantDetailsViewModel @Inject constructor(
     fun setNin(nin: String) {
         if (this.nin.get() == nin) return
         this.nin.set(nin)
+
+        val inferredGender = getGenderFromNin(nin)
+        inferredGender?.let {
+            this.gender.set(it)
+        }
+    }
+
+    private fun getGenderFromNin(nin: String): Gender? {
+        return when {
+            nin.startsWith("CM", ignoreCase = true) -> Gender.MALE
+            nin.startsWith("CF", ignoreCase = true) -> Gender.FEMALE
+            else -> null
+        }
     }
 
     fun setChildNumber(childNumber: String) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -469,7 +469,7 @@
     <string name="visits_overview_client_name_column_label">Child Name</string>
     <string name="visits_overview_details_visit_date_label">Visit Date:</string>
     <string name="visits_overview_details_scheduled_visit_date_label">Scheduled Visit Date:</string>
-    <string name="visits_overview_details_historical_visit_date_label">Today\'s Visit Date:</string>
+    <string name="visits_overview_details_historical_visit_date_label">Visit Date:</string>
     <string name="visits_overview_details_missed_visit_date_label">Missed Visit Date:</string>
     <string name="visits_overview_details_visit_schedule_label">Visit Schedule:</string>
     <string name="visits_overview_details_phone_number_label">Phone Number:</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -389,7 +389,7 @@
     <string name="vaccine_dialog_select_vaccine_label">Vaccine</string>
     <string name="vaccine_dialog_dose_label">Dose</string>
     <string name="vaccine_dialog_vaccine_date_label">Date</string>
-    <string name="participant_registration_historical_data_title">Historical Data</string>
+    <string name="participant_registration_historical_data_title">Past Visits</string>
     <string name="administered_vaccines_no_previous_vaccines">No previous vaccines</string>
     <string name="general_label_add">Add</string>
     <string name="remove_vaccine">Remove</string>
@@ -458,7 +458,7 @@
     <string name="participant_registration_details_error_no_birth_date">Please enter birth weight as integer</string>
     <string name="visits_overview_title">Visits Overview</string>
     <string name="visits_overview_scheduled_visits_title">Scheduled Visits</string>
-    <string name="visits_overview_historical_visits_title">Historical Visits</string>
+    <string name="visits_overview_historical_visits_title">Visit History</string>
     <string name="visits_overview_missed_visits_title">Missed Visits</string>
     <string name="visits_overview_start_date_label">Start Date</string>
     <string name="visits_overview_end_date_label">End Date</string>
@@ -469,7 +469,7 @@
     <string name="visits_overview_client_name_column_label">Child Name</string>
     <string name="visits_overview_details_visit_date_label">Visit Date:</string>
     <string name="visits_overview_details_scheduled_visit_date_label">Scheduled Visit Date:</string>
-    <string name="visits_overview_details_historical_visit_date_label">Historical Visit Date:</string>
+    <string name="visits_overview_details_historical_visit_date_label">Today\'s Visit Date:</string>
     <string name="visits_overview_details_missed_visit_date_label">Missed Visit Date:</string>
     <string name="visits_overview_details_visit_schedule_label">Visit Schedule:</string>
     <string name="visits_overview_details_phone_number_label">Phone Number:</string>
@@ -494,7 +494,7 @@
     <string name="selected_vaccines_label">Selected Vaccines:</string>
     <string name="vaccines_excel_report_date_range_label_set">Date Range: %1$s - %2$s</string>
     <string name="vaccines_excel_report_date_range_label_not_set">Date Range: not set, data comes from the entire period</string>
-    <string name="go_to_historical_visits">Historical Visits</string>
+    <string name="go_to_historical_visits">Visit History</string>
     <string name="dialog_multiple_visits_text">Please select a visit:</string>
     <string name="vaccine_change_date_label">Change Date</string>
     <string name="dialog_missing_substances_empty_text_validation_message">Provide a reason</string>


### PR DESCRIPTION
…ture date to submit this visit

https://sd-vxnaid.atlassian.net/browse/VRVU-287  cc @druchniewicz 

**What is  fixed.**

- Historical Visits Overview button name change to Visit History
- Historical Data page name change to Past Visits
- the first 2 letters of NIN can be matched with the gender: For example, if the NIN starts with CM, the gender default should be male, and if user selects female, the system should flag.
