### PR TITLE
Remove the Close Button During Save Visit

### DIFF
--- a/app/src/main/java/com/jnj/vaccinetracker/visit/dialog/VisitRegisteredSuccessDialog.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visit/dialog/VisitRegisteredSuccessDialog.kt
@@ -46,26 +46,15 @@ import javax.inject.Inject
  * @author timonelen
  * @version 1
  */
-class VisitRegisteredSuccessDialog : BaseDialogFragment(),
-    ScheduleVisitDatePickerDialog.OnDateSelectedListener {
+class VisitRegisteredSuccessDialog : BaseDialogFragment(), ScheduleVisitDatePickerDialog.OnDateSelectedListener {
 
     companion object {
         private const val ARG_NEXT_VISIT = "next_visit"
         private const val PARTICIPANT = "participant"
         private const val CURRENT_VISIT_UUID = "currentVisitUuid"
 
-        fun create(
-            nextVisit: UpcomingVisit?,
-            participant: ParticipantSummaryUiModel?,
-            currentVisitUuid: String?
-        ): VisitRegisteredSuccessDialog {
-            return VisitRegisteredSuccessDialog().apply {
-                arguments = bundleOf(
-                    ARG_NEXT_VISIT to nextVisit,
-                    PARTICIPANT to participant,
-                    CURRENT_VISIT_UUID to currentVisitUuid
-                )
-            }
+        fun create(nextVisit: UpcomingVisit?, participant: ParticipantSummaryUiModel?, currentVisitUuid: String?): VisitRegisteredSuccessDialog {
+            return VisitRegisteredSuccessDialog().apply { arguments = bundleOf(ARG_NEXT_VISIT to nextVisit, PARTICIPANT to participant, CURRENT_VISIT_UUID to currentVisitUuid) }
         }
     }
 
@@ -81,22 +70,13 @@ class VisitRegisteredSuccessDialog : BaseDialogFragment(),
     private val nextVisit: UpcomingVisit? by lazy { requireArguments().getParcelable(ARG_NEXT_VISIT) }
     private var visitDate: DateTime? = null
     private var canFinish: Boolean = false
-    private val participant: ParticipantSummaryUiModel? by lazy {
-        requireArguments().getParcelable(
-            PARTICIPANT
-        )
-    }
+    private val participant: ParticipantSummaryUiModel? by lazy { requireArguments().getParcelable(PARTICIPANT) }
     private val currentVisitUuid: String? by lazy { requireArguments().getString(CURRENT_VISIT_UUID) }
-    @Inject
-    lateinit var createVisitUseCase: CreateVisitUseCase
-    @Inject
-    lateinit var userRepository: UserRepository
-    @Inject
-    lateinit var syncSettingsRepository: SyncSettingsRepository
-    @Inject
-    lateinit var configurationManager: ConfigurationManager
-    @Inject
-    lateinit var visitManager: VisitManager
+    @Inject lateinit var createVisitUseCase: CreateVisitUseCase
+    @Inject lateinit var userRepository: UserRepository
+    @Inject lateinit var syncSettingsRepository: SyncSettingsRepository
+    @Inject lateinit var configurationManager: ConfigurationManager
+    @Inject lateinit var visitManager: VisitManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -105,45 +85,29 @@ class VisitRegisteredSuccessDialog : BaseDialogFragment(),
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        binding = DataBindingUtil.inflate(
-            inflater,
-            R.layout.dialog_visit_registered_success,
-            container,
-            false
-        )
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        binding = DataBindingUtil.inflate(inflater, R.layout.dialog_visit_registered_success, container, false)
         binding.nextVisit = nextVisit
         binding.executePendingBindings()
         visitDateTextView = binding.root.findViewById(R.id.next_visit_date_value)
         visitScheduleResultTextView = binding.root.findViewById(R.id.visit_schedule_result_label)
-        nextVisitDateContainerLinearLayout =
-            binding.root.findViewById(R.id.next_visit_date_container)
-        proposedDateContainerLinearLayout =
-            binding.root.findViewById(R.id.proposed_next_visit_date_container)
+        nextVisitDateContainerLinearLayout = binding.root.findViewById(R.id.next_visit_date_container)
+        proposedDateContainerLinearLayout = binding.root.findViewById(R.id.proposed_next_visit_date_container)
         saveVisitButton = binding.root.findViewById(R.id.btn_save_visit)
         closeButton = binding.root.findViewById(R.id.btn_finish)
         proposedDateTextVisit = binding.root.findViewById(R.id.proposed_next_visit_date_value)
-
+        
         closeButton.visibility = View.GONE
 
         lifecycleScope.launch {
             val nextVisitProposedDateAsLocalDate = findProposedNextVisitDateAsLocalDate()
             proposedDateTextVisit.text = nextVisitProposedDateAsLocalDate?.toString() ?: ""
 
-            val nextVisitProposedDateAsDate = Date.from(
-                nextVisitProposedDateAsLocalDate
-                    ?.atStartOfDay(ZoneId.of(Constants.UTC_TIME_ZONE_NAME))?.toInstant()
-            )
+            val nextVisitProposedDateAsDate = Date.from(nextVisitProposedDateAsLocalDate
+                ?.atStartOfDay(ZoneId.of(Constants.UTC_TIME_ZONE_NAME))?.toInstant())
             val proposedDateAsDate = nextVisitProposedDateAsDate?.let { DateTime.fromUnix(it.time) }
             binding.nextVisitDatePickerButton.setOnClickListener {
-                ScheduleVisitDatePickerDialog(
-                    proposedDateAsDate,
-                    this@VisitRegisteredSuccessDialog
-                ).show(childFragmentManager, "scheduleVisitDatePickerDialog")
+                ScheduleVisitDatePickerDialog(proposedDateAsDate, this@VisitRegisteredSuccessDialog).show(childFragmentManager, "scheduleVisitDatePickerDialog")
             }
 
             if (proposedDateAsDate != null) {
@@ -152,46 +116,28 @@ class VisitRegisteredSuccessDialog : BaseDialogFragment(),
         }
 
         binding.btnSaveVisit.setOnClickListener {
-            lifecycleScope.launch {
-                try {
-                    validateDate()
-                    if (visitDate != null) {
-                        createVisitUseCase.createVisit(
-                            buildNextVisitObject(
-                                participant!!,
-                                Date(visitDate!!.unixMillisLong)
-                            )
-                        )
-                        val visitDateAsText = visitDate!!.format(DateFormat.FORMAT_DATE)
-                        visitScheduleResultTextView.text =
-                            "${getString(R.string.visit_schedule_visit_saved_successfully_label)} $visitDateAsText"
-                        visitScheduleResultTextView.setTextColor(
-                            ContextCompat.getColor(
-                                requireContext(),
-                                R.color.successDark
-                            )
-                        )
-                        nextVisitDateContainerLinearLayout.visibility = View.GONE
-                        proposedDateContainerLinearLayout.visibility = View.GONE
-                        saveVisitButton.visibility = View.GONE
-                        closeButton.visibility = View.VISIBLE
-
-                        val layoutParams = closeButton.layoutParams as ConstraintLayout.LayoutParams
-                        layoutParams.horizontalBias = 0.5f
-                        closeButton.layoutParams = layoutParams
-                        canFinish = true
-                    }
-                } catch (ex: Exception) {
-                    visitScheduleResultTextView.text =
-                        getString(R.string.visit_schedule_visit_failed)
-                    visitScheduleResultTextView.setTextColor(
-                        ContextCompat.getColor(
-                            requireContext(),
-                            com.google.android.material.R.color.design_default_color_error
-                        )
-                    )
-                }
-            }
+           lifecycleScope.launch {
+               try {
+                   validateDate()
+                   if (visitDate != null) {
+                       createVisitUseCase.createVisit(buildNextVisitObject(participant!!, Date(visitDate!!.unixMillisLong)))
+                       val visitDateAsText = visitDate!!.format(DateFormat.FORMAT_DATE)
+                       visitScheduleResultTextView.text = "${getString(R.string.visit_schedule_visit_saved_successfully_label)} $visitDateAsText"
+                       visitScheduleResultTextView.setTextColor(ContextCompat.getColor(requireContext(), R.color.successDark))
+                       nextVisitDateContainerLinearLayout.visibility = View.GONE
+                       proposedDateContainerLinearLayout.visibility = View.GONE
+                       saveVisitButton.visibility = View.GONE
+                       closeButton.visibility = View.VISIBLE
+                       val layoutParams = closeButton.layoutParams as ConstraintLayout.LayoutParams
+                       layoutParams.horizontalBias = 0.5f
+                       closeButton.layoutParams = layoutParams
+                       canFinish = true
+                   }
+               } catch (ex: Exception) {
+                   visitScheduleResultTextView.text = getString(R.string.visit_schedule_visit_failed)
+                   visitScheduleResultTextView.setTextColor(ContextCompat.getColor(requireContext(), com.google.android.material.R.color.design_default_color_error))
+               }
+           }
         }
 
         binding.btnFinish.setOnClickListener {
@@ -215,10 +161,7 @@ class VisitRegisteredSuccessDialog : BaseDialogFragment(),
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
-    private suspend fun buildNextVisitObject(
-        participant: ParticipantSummaryUiModel,
-        visitDate: Date
-    ): CreateVisit {
+    private suspend fun buildNextVisitObject(participant: ParticipantSummaryUiModel, visitDate: Date): CreateVisit {
         val operatorUuid = userRepository.getUser()?.uuid
             ?: throw OperatorUuidNotAvailableException("Operator UUID not available")
         val locationUuid = syncSettingsRepository.getSiteUuid()
@@ -241,19 +184,14 @@ class VisitRegisteredSuccessDialog : BaseDialogFragment(),
     private suspend fun findVisitTypeOfNextVisit(): String {
         val participantBirthDate = participant!!.birthDateText
         val participantVisits = visitManager.getVisitsForParticipant(participant!!.participantUuid)
-        val currentVisitType = SubstancesDataUtil.getVisitTypeForCurrentVisit(
-            participantBirthDate,
-            participantVisits,
-            configurationManager
-        )
+        val currentVisitType = SubstancesDataUtil.getVisitTypeForCurrentVisit(participantBirthDate, participantVisits, configurationManager)
         val substancesConfig = configurationManager.getSubstancesConfig()
         val currentVaccine = substancesConfig.find { it.visitType == currentVisitType }
         if (currentVaccine == null) {
             return ""
         }
-        val nextVaccine =
-            substancesConfig.filter { it.weeksAfterBirth > currentVaccine.weeksAfterBirth }
-                .minByOrNull { it.weeksAfterBirth }
+        val nextVaccine = substancesConfig.filter { it.weeksAfterBirth > currentVaccine.weeksAfterBirth }
+            .minByOrNull { it.weeksAfterBirth }
         if (nextVaccine == null) {
             return ""
         }
@@ -263,8 +201,7 @@ class VisitRegisteredSuccessDialog : BaseDialogFragment(),
 
     private fun validateDate() {
         if (visitDate == null) {
-            val dateValidationText =
-                getString(R.string.dialog_missing_substances_empty_date_validation_message)
+            val dateValidationText = getString(R.string.dialog_missing_substances_empty_date_validation_message)
             binding.nextVisitDateValue.error = dateValidationText
             val hintTextColor = ContextCompat.getColor(requireContext(), R.color.errorLight)
             binding.nextVisitDateValue.setHintTextColor(hintTextColor)

--- a/app/src/main/java/com/jnj/vaccinetracker/visit/dialog/VisitRegisteredSuccessDialog.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visit/dialog/VisitRegisteredSuccessDialog.kt
@@ -96,7 +96,6 @@ class VisitRegisteredSuccessDialog : BaseDialogFragment(), ScheduleVisitDatePick
         saveVisitButton = binding.root.findViewById(R.id.btn_save_visit)
         closeButton = binding.root.findViewById(R.id.btn_finish)
         proposedDateTextVisit = binding.root.findViewById(R.id.proposed_next_visit_date_value)
-        
         closeButton.visibility = View.GONE
 
         lifecycleScope.launch {

--- a/app/src/main/java/com/jnj/vaccinetracker/visit/dialog/VisitRegisteredSuccessDialog.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visit/dialog/VisitRegisteredSuccessDialog.kt
@@ -46,15 +46,26 @@ import javax.inject.Inject
  * @author timonelen
  * @version 1
  */
-class VisitRegisteredSuccessDialog : BaseDialogFragment(), ScheduleVisitDatePickerDialog.OnDateSelectedListener {
+class VisitRegisteredSuccessDialog : BaseDialogFragment(),
+    ScheduleVisitDatePickerDialog.OnDateSelectedListener {
 
     companion object {
         private const val ARG_NEXT_VISIT = "next_visit"
         private const val PARTICIPANT = "participant"
         private const val CURRENT_VISIT_UUID = "currentVisitUuid"
 
-        fun create(nextVisit: UpcomingVisit?, participant: ParticipantSummaryUiModel?, currentVisitUuid: String?): VisitRegisteredSuccessDialog {
-            return VisitRegisteredSuccessDialog().apply { arguments = bundleOf(ARG_NEXT_VISIT to nextVisit, PARTICIPANT to participant, CURRENT_VISIT_UUID to currentVisitUuid) }
+        fun create(
+            nextVisit: UpcomingVisit?,
+            participant: ParticipantSummaryUiModel?,
+            currentVisitUuid: String?
+        ): VisitRegisteredSuccessDialog {
+            return VisitRegisteredSuccessDialog().apply {
+                arguments = bundleOf(
+                    ARG_NEXT_VISIT to nextVisit,
+                    PARTICIPANT to participant,
+                    CURRENT_VISIT_UUID to currentVisitUuid
+                )
+            }
         }
     }
 
@@ -70,13 +81,22 @@ class VisitRegisteredSuccessDialog : BaseDialogFragment(), ScheduleVisitDatePick
     private val nextVisit: UpcomingVisit? by lazy { requireArguments().getParcelable(ARG_NEXT_VISIT) }
     private var visitDate: DateTime? = null
     private var canFinish: Boolean = false
-    private val participant: ParticipantSummaryUiModel? by lazy { requireArguments().getParcelable(PARTICIPANT) }
+    private val participant: ParticipantSummaryUiModel? by lazy {
+        requireArguments().getParcelable(
+            PARTICIPANT
+        )
+    }
     private val currentVisitUuid: String? by lazy { requireArguments().getString(CURRENT_VISIT_UUID) }
-    @Inject lateinit var createVisitUseCase: CreateVisitUseCase
-    @Inject lateinit var userRepository: UserRepository
-    @Inject lateinit var syncSettingsRepository: SyncSettingsRepository
-    @Inject lateinit var configurationManager: ConfigurationManager
-    @Inject lateinit var visitManager: VisitManager
+    @Inject
+    lateinit var createVisitUseCase: CreateVisitUseCase
+    @Inject
+    lateinit var userRepository: UserRepository
+    @Inject
+    lateinit var syncSettingsRepository: SyncSettingsRepository
+    @Inject
+    lateinit var configurationManager: ConfigurationManager
+    @Inject
+    lateinit var visitManager: VisitManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -85,27 +105,45 @@ class VisitRegisteredSuccessDialog : BaseDialogFragment(), ScheduleVisitDatePick
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        binding = DataBindingUtil.inflate(inflater, R.layout.dialog_visit_registered_success, container, false)
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        binding = DataBindingUtil.inflate(
+            inflater,
+            R.layout.dialog_visit_registered_success,
+            container,
+            false
+        )
         binding.nextVisit = nextVisit
         binding.executePendingBindings()
         visitDateTextView = binding.root.findViewById(R.id.next_visit_date_value)
         visitScheduleResultTextView = binding.root.findViewById(R.id.visit_schedule_result_label)
-        nextVisitDateContainerLinearLayout = binding.root.findViewById(R.id.next_visit_date_container)
-        proposedDateContainerLinearLayout = binding.root.findViewById(R.id.proposed_next_visit_date_container)
+        nextVisitDateContainerLinearLayout =
+            binding.root.findViewById(R.id.next_visit_date_container)
+        proposedDateContainerLinearLayout =
+            binding.root.findViewById(R.id.proposed_next_visit_date_container)
         saveVisitButton = binding.root.findViewById(R.id.btn_save_visit)
         closeButton = binding.root.findViewById(R.id.btn_finish)
         proposedDateTextVisit = binding.root.findViewById(R.id.proposed_next_visit_date_value)
+
+        closeButton.visibility = View.GONE
 
         lifecycleScope.launch {
             val nextVisitProposedDateAsLocalDate = findProposedNextVisitDateAsLocalDate()
             proposedDateTextVisit.text = nextVisitProposedDateAsLocalDate?.toString() ?: ""
 
-            val nextVisitProposedDateAsDate = Date.from(nextVisitProposedDateAsLocalDate
-                ?.atStartOfDay(ZoneId.of(Constants.UTC_TIME_ZONE_NAME))?.toInstant())
+            val nextVisitProposedDateAsDate = Date.from(
+                nextVisitProposedDateAsLocalDate
+                    ?.atStartOfDay(ZoneId.of(Constants.UTC_TIME_ZONE_NAME))?.toInstant()
+            )
             val proposedDateAsDate = nextVisitProposedDateAsDate?.let { DateTime.fromUnix(it.time) }
             binding.nextVisitDatePickerButton.setOnClickListener {
-                ScheduleVisitDatePickerDialog(proposedDateAsDate, this@VisitRegisteredSuccessDialog).show(childFragmentManager, "scheduleVisitDatePickerDialog")
+                ScheduleVisitDatePickerDialog(
+                    proposedDateAsDate,
+                    this@VisitRegisteredSuccessDialog
+                ).show(childFragmentManager, "scheduleVisitDatePickerDialog")
             }
 
             if (proposedDateAsDate != null) {
@@ -114,28 +152,46 @@ class VisitRegisteredSuccessDialog : BaseDialogFragment(), ScheduleVisitDatePick
         }
 
         binding.btnSaveVisit.setOnClickListener {
-           lifecycleScope.launch {
-               try {
-                   validateDate()
-                   if (visitDate != null) {
-                       createVisitUseCase.createVisit(buildNextVisitObject(participant!!, Date(visitDate!!.unixMillisLong)))
-                       val visitDateAsText = visitDate!!.format(DateFormat.FORMAT_DATE)
-                       visitScheduleResultTextView.text = "${getString(R.string.visit_schedule_visit_saved_successfully_label)} $visitDateAsText"
-                       visitScheduleResultTextView.setTextColor(ContextCompat.getColor(requireContext(), R.color.successDark))
-                       nextVisitDateContainerLinearLayout.visibility = View.GONE
-                       proposedDateContainerLinearLayout.visibility = View.GONE
-                       saveVisitButton.visibility = View.GONE
+            lifecycleScope.launch {
+                try {
+                    validateDate()
+                    if (visitDate != null) {
+                        createVisitUseCase.createVisit(
+                            buildNextVisitObject(
+                                participant!!,
+                                Date(visitDate!!.unixMillisLong)
+                            )
+                        )
+                        val visitDateAsText = visitDate!!.format(DateFormat.FORMAT_DATE)
+                        visitScheduleResultTextView.text =
+                            "${getString(R.string.visit_schedule_visit_saved_successfully_label)} $visitDateAsText"
+                        visitScheduleResultTextView.setTextColor(
+                            ContextCompat.getColor(
+                                requireContext(),
+                                R.color.successDark
+                            )
+                        )
+                        nextVisitDateContainerLinearLayout.visibility = View.GONE
+                        proposedDateContainerLinearLayout.visibility = View.GONE
+                        saveVisitButton.visibility = View.GONE
+                        closeButton.visibility = View.VISIBLE
 
-                       val layoutParams = closeButton.layoutParams as ConstraintLayout.LayoutParams
-                       layoutParams.horizontalBias = 0.5f
-                       closeButton.layoutParams = layoutParams
-                       canFinish = true
-                   }
-               } catch (ex: Exception) {
-                   visitScheduleResultTextView.text = getString(R.string.visit_schedule_visit_failed)
-                   visitScheduleResultTextView.setTextColor(ContextCompat.getColor(requireContext(), com.google.android.material.R.color.design_default_color_error))
-               }
-           }
+                        val layoutParams = closeButton.layoutParams as ConstraintLayout.LayoutParams
+                        layoutParams.horizontalBias = 0.5f
+                        closeButton.layoutParams = layoutParams
+                        canFinish = true
+                    }
+                } catch (ex: Exception) {
+                    visitScheduleResultTextView.text =
+                        getString(R.string.visit_schedule_visit_failed)
+                    visitScheduleResultTextView.setTextColor(
+                        ContextCompat.getColor(
+                            requireContext(),
+                            com.google.android.material.R.color.design_default_color_error
+                        )
+                    )
+                }
+            }
         }
 
         binding.btnFinish.setOnClickListener {
@@ -159,7 +215,10 @@ class VisitRegisteredSuccessDialog : BaseDialogFragment(), ScheduleVisitDatePick
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
-    private suspend fun buildNextVisitObject(participant: ParticipantSummaryUiModel, visitDate: Date): CreateVisit {
+    private suspend fun buildNextVisitObject(
+        participant: ParticipantSummaryUiModel,
+        visitDate: Date
+    ): CreateVisit {
         val operatorUuid = userRepository.getUser()?.uuid
             ?: throw OperatorUuidNotAvailableException("Operator UUID not available")
         val locationUuid = syncSettingsRepository.getSiteUuid()
@@ -182,14 +241,19 @@ class VisitRegisteredSuccessDialog : BaseDialogFragment(), ScheduleVisitDatePick
     private suspend fun findVisitTypeOfNextVisit(): String {
         val participantBirthDate = participant!!.birthDateText
         val participantVisits = visitManager.getVisitsForParticipant(participant!!.participantUuid)
-        val currentVisitType = SubstancesDataUtil.getVisitTypeForCurrentVisit(participantBirthDate, participantVisits, configurationManager)
+        val currentVisitType = SubstancesDataUtil.getVisitTypeForCurrentVisit(
+            participantBirthDate,
+            participantVisits,
+            configurationManager
+        )
         val substancesConfig = configurationManager.getSubstancesConfig()
         val currentVaccine = substancesConfig.find { it.visitType == currentVisitType }
         if (currentVaccine == null) {
             return ""
         }
-        val nextVaccine = substancesConfig.filter { it.weeksAfterBirth > currentVaccine.weeksAfterBirth }
-            .minByOrNull { it.weeksAfterBirth }
+        val nextVaccine =
+            substancesConfig.filter { it.weeksAfterBirth > currentVaccine.weeksAfterBirth }
+                .minByOrNull { it.weeksAfterBirth }
         if (nextVaccine == null) {
             return ""
         }
@@ -199,7 +263,8 @@ class VisitRegisteredSuccessDialog : BaseDialogFragment(), ScheduleVisitDatePick
 
     private fun validateDate() {
         if (visitDate == null) {
-            val dateValidationText = getString(R.string.dialog_missing_substances_empty_date_validation_message)
+            val dateValidationText =
+                getString(R.string.dialog_missing_substances_empty_date_validation_message)
             binding.nextVisitDateValue.error = dateValidationText
             val hintTextColor = ContextCompat.getColor(requireContext(), R.color.errorLight)
             binding.nextVisitDateValue.setHintTextColor(hintTextColor)

--- a/app/src/main/res/layout/dialog_visit_registered_success.xml
+++ b/app/src/main/res/layout/dialog_visit_registered_success.xml
@@ -252,14 +252,16 @@
             android:layout_marginTop="52dp"
             android:layout_marginEnd="16dp"
             android:layout_marginBottom="16dp"
+            android:paddingHorizontal="16dp"
+            android:paddingVertical="4dp"
             android:text="@string/general_label_close"
             android:textAppearance="@style/ButtonTextStyling"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.316"
+            app:layout_constraintHorizontal_bias="0.473"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/next_visit_date_container"
-            app:layout_constraintVertical_bias="0.381" />
+            app:layout_constraintVertical_bias="0.407" />
 
         <Button
             android:id="@+id/btn_save_visit"
@@ -269,14 +271,16 @@
             android:layout_marginEnd="16dp"
             android:layout_marginBottom="16dp"
             android:backgroundTint="@color/colorPrimary"
+            android:paddingHorizontal="16dp"
+            android:paddingVertical="4dp"
             android:text="@string/visit_schedule_next_visit_schedule_new_visit_button_label"
             android:textAppearance="@style/ButtonTextStyling"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.768"
+            app:layout_constraintHorizontal_bias="0.465"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/next_visit_date_container"
-            app:layout_constraintVertical_bias="0.372" />
+            app:layout_constraintVertical_bias="0.407" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -445,7 +445,7 @@
     <string name="participant_matching_btn_edit_participant">Update Child Details</string>
     <string name="participant_update_label_success">Child successfully updated</string>
     <string name="vaccine_capture_date_label">Capture Date</string>
-    <string name="visit_schedule_next_visit_schedule_new_visit_button_label">Save Visit</string>
+    <string name="visit_schedule_next_visit_schedule_new_visit_button_label">Save Next Visit Date</string>
     <string name="refer_finish_visit_text">----  choose how to finish the visit  ----</string>
     <string name="label_change_visit_type">Change Visit Type</string>
     <string name="adverse_effects_page_failed_text">Reporting of adverse effects failed.</string>


### PR DESCRIPTION
This PR focuses on:

1.  removing the close button by making its visibility gone 
2. until the save next visit date button is pressed

This fix prevents operators from closing a visit before setting and saving a next visit date