### PR TITLE
Update Flow 1: Update Child details During Registration

### DIFF
--- a/app/src/main/java/com/jnj/vaccinetracker/participantflow/screens/ParticipantFlowMatchingFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/participantflow/screens/ParticipantFlowMatchingFragment.kt
@@ -89,8 +89,23 @@ class ParticipantFlowMatchingFragment : BaseFragment() {
             }.launchIn(lifecycleOwner)
 
         viewModel.items.observe(lifecycleOwner) { items ->
-            adapter.updateItems(items.orEmpty())
+            val itemList = items.orEmpty()
+            adapter.updateItems(itemList)
+
+            when {
+                itemList.size == 1 -> {
+                    viewModel.setSelectedParticipant(itemList[0])
+                    setButtonsVisibility(true)
+                }
+                itemList.size > 1 -> {
+                    setButtonsVisibility(false)
+                }
+                else -> {
+                    setButtonsVisibility(false)
+                }
+            }
         }
+
         viewModel.errorMessage.observe(lifecycleOwner) { errorMessage ->
             errorSnackbar?.dismiss()
 
@@ -140,10 +155,20 @@ class ParticipantFlowMatchingFragment : BaseFragment() {
             motherName = motherName))
     }
 
+    private fun setButtonsVisibility(visible: Boolean) {
+        val visibility = if (visible) View.VISIBLE else View.GONE
+        binding.btnNewParticipant.visibility = visibility
+        binding.btnMatchParticipant.visibility = visibility
+        binding.btnReportAdverseEffects.visibility = visibility
+
+        (activity as AppCompatActivity).supportActionBar?.setDisplayHomeAsUpEnabled(!visible)
+    }
+
     private fun onItemSelected(matchingListItem: ParticipantFlowMatchingViewModel.MatchingListItem) {
         val selectedParticipant = viewModel.setSelectedParticipant(matchingListItem)
         if (selectedParticipant != null) {
             flowViewModel.selectedParticipant.value = selectedParticipant
+            setButtonsVisibility(true)
         }
     }
 

--- a/app/src/main/java/com/jnj/vaccinetracker/visit/VisitActivity.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visit/VisitActivity.kt
@@ -26,6 +26,8 @@ import com.jnj.vaccinetracker.common.ui.BaseActivity
 import com.jnj.vaccinetracker.common.ui.SyncBanner
 import com.jnj.vaccinetracker.common.ui.animateNavigationDirection
 import com.jnj.vaccinetracker.databinding.ActivityVisitBinding
+import com.jnj.vaccinetracker.participantflow.ParticipantFlowActivity
+import com.jnj.vaccinetracker.participantflow.ParticipantFlowViewModel
 import com.jnj.vaccinetracker.participantflow.model.ParticipantSummaryUiModel
 import com.jnj.vaccinetracker.register.dialogs.VaccineDialog
 import com.jnj.vaccinetracker.visit.dialog.DialogScheduleMissingSubstances
@@ -75,6 +77,7 @@ class VisitActivity :
     private val participantArg: ParticipantSummaryUiModel by lazy { intent.getParcelableExtra(EXTRA_PARTICIPANT)!! }
     private val newRegisteredParticipantArg: Boolean by lazy { intent.getBooleanExtra(EXTRA_TYPE, false) }
     private val viewModel: VisitViewModel by viewModels { viewModelFactory }
+    private val participantViewModel: ParticipantFlowViewModel by viewModels { viewModelFactory }
     private val scanModel:ScanBarcodeViewModel by viewModels{ viewModelFactory }
     private lateinit var binding: ActivityVisitBinding
     private var isFirstTab = true
@@ -111,16 +114,16 @@ class VisitActivity :
             onSubmit()
         }
         binding.tabLayout.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
-          override fun onTabSelected(tab: TabLayout.Tab) {
-            makeSubmitBtnVisible()
-            isFirstTab = (tab.position == 0)
+            override fun onTabSelected(tab: TabLayout.Tab) {
+                makeSubmitBtnVisible()
+                isFirstTab = (tab.position == 0)
 
-            if (isFirstTab) {
-                makeAddVaccineButtonInvisible()
-            } else {
-                makeAddVaccineButtonVisible()
+                if (isFirstTab) {
+                    makeAddVaccineButtonInvisible()
+                } else {
+                    makeAddVaccineButtonVisible()
+                }
             }
-        }
 
             override fun onTabUnselected(tab: TabLayout.Tab) {
                 // Optional: Handle tab unselected logic here
@@ -363,7 +366,7 @@ class VisitActivity :
         when {
             currentFragment is ContraindicationsFragment && currentFragment.isVisible -> {
                 // When in ContraindicationsFragment, launch ParticipantFlowActivity
-                goToMatchParticipantFragment()
+                goToRegisteredParticipant()
             }
             currentFragment is ReferralFragment && currentFragment.isVisible -> {
                 handleReferralFragmentBackPress(currentFragment)
@@ -376,6 +379,15 @@ class VisitActivity :
     }
 
     private fun goToMatchParticipantFragment() {
+        finish()
+    }
+
+    private fun goToRegisteredParticipant() {
+        val intent = Intent(this, ParticipantFlowActivity::class.java)
+        val participantId = viewModel.participant.value?.participantId
+        intent.putExtra(Constants.CALL_NAVIGATE_TO_MATCH_SCREEN, true)
+        intent.putExtra(Constants.PARTICIPANT_MATCH_ID, participantId)
+        startActivity(intent)
         finish()
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -136,7 +136,7 @@
     <string name="participant_registration_details_action_register_participant">Register a Child</string>
     <string name="participant_registration_details_description">Please Enter New Child\'s Details</string>
     <string name="participant_update_details_description" translatable="false">Update Child Details</string>
-    <string name="participant_registration_details_action_update_participant" translatable="false">Update Child Details</string>
+    <string name="participant_registration_details_action_update_participant" translatable="false">Save</string>
     <string name="participant_registration_details_label_participant_id">Child Number</string>
     <string name="participant_registration_details_label_confirm_participant_id">Confirm Child Number</string>
     <string name="participant_registration_load_camera">Load a Camera</string>


### PR DESCRIPTION
This PR focuses on;

1. Adjusting the back arrow button on the contraindications to lead you to the child matching page so that child details can be update.
          - Update the registration child details
          - Update the information about past visits
 The proceed with the vaccination normally