### PR TITLE
Update flow 2: Update child details starting in visits overview Page

### DIFF
--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/activity/VisitsOverviewFlowActivity.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/activity/VisitsOverviewFlowActivity.kt
@@ -8,11 +8,13 @@ import androidx.activity.viewModels
 import androidx.annotation.RequiresApi
 import androidx.databinding.DataBindingUtil
 import com.jnj.vaccinetracker.R
+import com.jnj.vaccinetracker.common.data.models.Constants
 import com.jnj.vaccinetracker.common.data.models.NavigationDirection
 import com.jnj.vaccinetracker.common.helpers.logWarn
 import com.jnj.vaccinetracker.common.ui.BaseActivity
 import com.jnj.vaccinetracker.common.ui.animateNavigationDirection
 import com.jnj.vaccinetracker.databinding.ActivityVisitOverviewFlowBinding
+import com.jnj.vaccinetracker.participantflow.ParticipantFlowActivity
 import com.jnj.vaccinetracker.visitsoverview.model.VisitsOverviewViewModel
 import com.jnj.vaccinetracker.visitsoverview.screens.VisitsOverviewFragment
 
@@ -60,12 +62,16 @@ class VisitsOverviewFlowActivity : BaseActivity() {
             }
 
             val transaction = supportFragmentManager.beginTransaction()
-
             transaction.animateNavigationDirection(navigationDirection)
-
-            transaction
-                .replace(R.id.fragment_container, newFragment)
-                .commit()
+            transaction.replace(R.id.fragment_container, newFragment).commit()
         }
+    }
+
+    fun goToRegisteredParticipant(childID: String) {
+        val intent = Intent(this, ParticipantFlowActivity::class.java)
+        intent.putExtra(Constants.CALL_NAVIGATE_TO_MATCH_SCREEN, true)
+        intent.putExtra(Constants.PARTICIPANT_MATCH_ID, childID)
+        startActivity(intent)
+        finish()
     }
 }

--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/dialog/VisitDetailsDialog.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/dialog/VisitDetailsDialog.kt
@@ -1,15 +1,19 @@
 package com.jnj.vaccinetracker.visitsoverview.dialog
 
+import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
 import androidx.databinding.DataBindingUtil
 import com.jnj.vaccinetracker.R
 import com.jnj.vaccinetracker.common.data.models.Constants
+import com.jnj.vaccinetracker.common.helpers.logInfo
 import com.jnj.vaccinetracker.common.ui.BaseDialogFragment
 import com.jnj.vaccinetracker.databinding.DialogVisitDetailsBinding
+import com.jnj.vaccinetracker.visitsoverview.activity.VisitsOverviewFlowActivity
 import com.jnj.vaccinetracker.visitsoverview.dto.VisitDetailsDTO
 
 class VisitDetailsDialog : BaseDialogFragment() {
@@ -18,6 +22,7 @@ class VisitDetailsDialog : BaseDialogFragment() {
     private lateinit var visitDetails: VisitDetailsDTO
     private lateinit var visitKey: String
 
+    @RequiresApi(Build.VERSION_CODES.O)
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -33,7 +38,11 @@ class VisitDetailsDialog : BaseDialogFragment() {
         setupLabels()
         binding.visitDetails = visitDetails
         binding.closeButton.setOnClickListener { dismissAllowingStateLoss() }
-
+        binding.childDetailsButton.setOnClickListener {
+            val childId = visitDetails.clientID
+            (activity as? VisitsOverviewFlowActivity)?. goToRegisteredParticipant(childId)
+            dismissAllowingStateLoss()
+        }
         return binding.root
     }
 

--- a/app/src/main/res/layout/dialog_visit_details.xml
+++ b/app/src/main/res/layout/dialog_visit_details.xml
@@ -161,11 +161,27 @@
 
         </TableLayout>
 
-        <Button
-            android:id="@+id/close_button"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:text="@string/visits_overview_details_close_button_label" />
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/close_button"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:text="@string/visits_overview_details_close_button_label" />
+
+            <Button
+                android:id="@+id/edit_button"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:text="@string/visits_overview_details_edit_button_label" />
+        </LinearLayout>
     </LinearLayout>
 </layout>

--- a/app/src/main/res/layout/dialog_visit_details.xml
+++ b/app/src/main/res/layout/dialog_visit_details.xml
@@ -176,7 +176,7 @@
                 android:text="@string/visits_overview_details_close_button_label" />
 
             <Button
-                android:id="@+id/edit_button"
+                android:id="@+id/child_details_button"
                 android:layout_width="0dp"
                 android:layout_weight="1"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -486,6 +486,7 @@
     <string name="patient_details_dialog_header"> Child Details:</string>
     <string name="visits_overview_details_client_name_label">Child Name:</string>
     <string name="visits_overview_details_close_button_label">Close</string>
+    <string name="visits_overview_details_edit_button_label">Child Details</string>
     <string name="visits_overview_total_visit_count_label">Total Visit Count: %1$d</string>
     <string name="visits_overview_view_details_label">View Details</string>
     <string name="visits_overview_download_excel_button_label">Download Excel</string>


### PR DESCRIPTION
This PR focuses on;

1. Adjusting the pop up when the eye icon in the visits is pressed to include a second button  CHILD DETAILS
2. This button will to the child matching page so that child details can be update.
      - Update the child details
      - Update the information about past visits
