### PR TITLE
Vaccination Date Validation on Past Visits

### DIFF
--- a/app/src/main/java/com/jnj/vaccinetracker/register/dialogs/HistoricalVisitDateDialog.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/register/dialogs/HistoricalVisitDateDialog.kt
@@ -1,5 +1,6 @@
 package com.jnj.vaccinetracker.register.dialogs
 
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
@@ -7,31 +8,45 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.DatePicker
+import android.widget.Toast
+import androidx.annotation.RequiresApi
 import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.activityViewModels
 import com.jnj.vaccinetracker.R
 import com.jnj.vaccinetracker.common.helpers.findParent
 import com.jnj.vaccinetracker.common.ui.BaseDialogFragment
 import com.jnj.vaccinetracker.databinding.DialogHistoricalVisitDateBinding
+import com.jnj.vaccinetracker.register.screens.RegisterParticipantHistoricalDataViewModel
 import com.soywiz.klock.DateTime
 import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
 
-class HistoricalVisitDateDialog() : BaseDialogFragment() {
+class HistoricalVisitDateDialog : BaseDialogFragment() {
+
    private lateinit var btnOk: Button
    private lateinit var btnCancel: Button
    private lateinit var datePicker: DatePicker
    private var birthDate: String? = null
-
+   private var lastValidDate: Long? = null
    private lateinit var binding: DialogHistoricalVisitDateBinding
+   private val disabledDates = mutableSetOf<Long>()
+
+
+   private val viewModel: RegisterParticipantHistoricalDataViewModel by activityViewModels()
 
    companion object {
       private const val BIRTH_DATE_STR = "birthDateStr"
-      fun create(birthDate: String): HistoricalVisitDateDialog {
+      private const val VISIT_TYPE = "visitType"
+      private const val DISABLED_DATES_KEY = "disabled_dates"
+
+      fun create(birthDate: String, disabledDates: Set<Long>, visitType: String): HistoricalVisitDateDialog {
          val dialog = HistoricalVisitDateDialog()
          val args = Bundle().apply {
             putString(BIRTH_DATE_STR, birthDate)
+            putString(DISABLED_DATES_KEY, disabledDates.joinToString(","))
+            putString(VISIT_TYPE, visitType)
          }
          dialog.arguments = args
          return dialog
@@ -40,21 +55,42 @@ class HistoricalVisitDateDialog() : BaseDialogFragment() {
 
    override fun onCreate(savedInstanceState: Bundle?) {
       super.onCreate(savedInstanceState)
-      arguments?.getString(BIRTH_DATE_STR)?.let { birthDateString ->
-         birthDate = birthDateString
+      arguments?.getString(BIRTH_DATE_STR)?.let { birthDate = it }
+
+      arguments?.getString(DISABLED_DATES_KEY)?.split(",")?.mapNotNull { it.toLongOrNull() }?.let {
+         disabledDates.addAll(viewModel.getAllDisabledDates())
+
       }
+
       setStyle(STYLE_NO_TITLE, 0)
       isCancelable = false
    }
 
+   @RequiresApi(Build.VERSION_CODES.O)
    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
       binding = DataBindingUtil.inflate(inflater, R.layout.dialog_historical_visit_date, container, false)
+
       initializeViews()
       setupDatePicker()
 
       btnOk.setOnClickListener {
          val selectedDate = DateTime(datePicker.year, datePicker.month + 1, datePicker.dayOfMonth)
+         val normalized = selectedDate.unixMillisLong.toMidnight()
+
+         if (disabledDates.contains(normalized)) {
+            Toast.makeText(requireContext(), "This date is already used. Please select another.", Toast.LENGTH_SHORT).show()
+            Log.d("DatePicker", "Blocked attempt to select a disabled date: $normalized")
+            return@setOnClickListener
+         }
+
          findParent<HistoricalVisitDateListener>()?.onDatePicked(selectedDate)
+         viewModel.addDisabledDate(normalized)
+
+         val visitType = arguments?.getString(VISIT_TYPE) ?: return@setOnClickListener
+         val currentDisabledDates = viewModel.getDisabledDatesForVisitType(visitType).toMutableSet()
+         currentDisabledDates.add(normalized)
+         viewModel.setDisabledDatesForVisitType(visitType, currentDisabledDates)
+
          dismissAllowingStateLoss()
       }
 
@@ -71,6 +107,7 @@ class HistoricalVisitDateDialog() : BaseDialogFragment() {
       btnCancel = binding.btnCancel
    }
 
+   @RequiresApi(Build.VERSION_CODES.O)
    private fun setupDatePicker() {
       val calendar = Calendar.getInstance()
       calendar.add(Calendar.DAY_OF_YEAR, -1)
@@ -81,13 +118,59 @@ class HistoricalVisitDateDialog() : BaseDialogFragment() {
             val sdf = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
             val birthDateMillis = sdf.parse(it)?.time ?: return
             datePicker.minDate = birthDateMillis
+            disabledDates.add(birthDateMillis.toMidnight())
          } catch (e: ParseException) {
             Log.e("DatePicker", "Invalid birth date format", e)
          }
       }
+
+      logDisabledDates()
+
+      datePicker.setOnDateChangedListener { _, year, month, day ->
+         val selectedCalendar = Calendar.getInstance()
+         selectedCalendar.set(year, month, day, 0, 0, 0)
+         selectedCalendar.set(Calendar.MILLISECOND, 0)
+         val selectedDateMillis = selectedCalendar.timeInMillis
+
+         if (disabledDates.contains(selectedDateMillis)) {
+            Toast.makeText(requireContext(), "This date is already used. Please select another.", Toast.LENGTH_SHORT).show()
+            Log.d("DatePicker", "Selected date is disabled")
+
+            lastValidDate?.let {
+               val resetCalendar = Calendar.getInstance()
+               resetCalendar.timeInMillis = it
+               datePicker.updateDate(
+                  resetCalendar.get(Calendar.YEAR),
+                  resetCalendar.get(Calendar.MONTH),
+                  resetCalendar.get(Calendar.DAY_OF_MONTH)
+               )
+            }
+         } else {
+            Log.d("DatePicker", "Selected date is valid")
+            lastValidDate = selectedDateMillis
+         }
+      }
+   }
+
+   private fun Long.toMidnight(): Long {
+      val cal = Calendar.getInstance()
+      cal.timeInMillis = this
+      cal.set(Calendar.HOUR_OF_DAY, 0)
+      cal.set(Calendar.MINUTE, 0)
+      cal.set(Calendar.SECOND, 0)
+      cal.set(Calendar.MILLISECOND, 0)
+      return cal.timeInMillis
    }
 
    interface HistoricalVisitDateListener {
       fun onDatePicked(date: DateTime)
+   }
+
+   private fun logDisabledDates() {
+      val sdf = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+      disabledDates.forEach { millis ->
+         val formattedDate = sdf.format(java.util.Date(millis))
+         Log.d("DisabledDate", "Disabled date: $formattedDate")
+      }
    }
 }

--- a/app/src/main/java/com/jnj/vaccinetracker/register/screens/HistoricalDataForVisitTypeFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/register/screens/HistoricalDataForVisitTypeFragment.kt
@@ -122,7 +122,11 @@ class HistoricalDataForVisitTypeFragment :
       if (!doesSubstancesHaveAnyDates() && viewModel.isLocalEdit.value != true) {
          viewModel.filterSubstanceDates.value = false
          val birthDate = allDataViewModel.getParticipantBirthDate()
-         HistoricalVisitDateDialog.create(birthDate = birthDate).show(childFragmentManager, TAG_HISTORICAL_VISIT_DATE)
+         HistoricalVisitDateDialog.create(
+             birthDate = birthDate,
+             disabledDates = emptySet(),
+             visitType = visitTypeName ?: Constants.EMPTY_STRING_VALUE
+         ).show(childFragmentManager, TAG_HISTORICAL_VISIT_DATE)
       }
       lifecycleScope.launch {
          getAllSubstancesFromAllVisitsForGivenVisitType(visitTypeName)

--- a/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantHistoricalDataFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantHistoricalDataFragment.kt
@@ -29,8 +29,10 @@ import com.jnj.vaccinetracker.databinding.FragmentRegisterHistoricalVisitsBindin
 import com.jnj.vaccinetracker.participantflow.model.ParticipantSummaryUiModel
 import com.jnj.vaccinetracker.register.RegisterParticipantFlowActivity
 import com.jnj.vaccinetracker.register.RegisterParticipantFlowViewModel
+import com.jnj.vaccinetracker.register.dialogs.HistoricalVisitDateDialog
 import com.jnj.vaccinetracker.register.dialogs.MultipleVisitsDialog
 import com.jnj.vaccinetracker.register.dialogs.RegisterParticipantSuccessfulDialog
+import com.soywiz.klock.DateTime
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -98,6 +100,19 @@ class RegisterParticipantHistoricalDataFragment : BaseFragment(),
                .show(childFragmentManager, TAG_SUCCESS_DIALOG)
          }
          .launchIn(lifecycleOwner.lifecycleScope)
+   }
+
+   private fun showDatePickerDialog() {
+     val birthDate = viewModel.getParticipantBirthDate()
+      val visitType = "historical"
+      val disabledDates = viewModel.getDisabledDatesForVisitType(visitType)
+
+      val dialog = HistoricalVisitDateDialog.create(birthDate, disabledDates, visitType)
+      dialog.show(parentFragmentManager, "HistoricalVisitDateDialog")
+   }
+
+   fun onDatePicked(date: DateTime) {
+      viewModel.setHistoricalVisitDate(date)
    }
 
    private fun setupClickListeners() {

--- a/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantHistoricalDataViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantHistoricalDataViewModel.kt
@@ -1,7 +1,10 @@
 package com.jnj.vaccinetracker.register.screens
 
 import android.os.Build
+import android.util.Log
 import androidx.annotation.RequiresApi
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import com.jnj.vaccinetracker.common.data.managers.VisitManager
 import com.jnj.vaccinetracker.common.data.models.Constants
 import com.jnj.vaccinetracker.common.data.repositories.UserRepository
@@ -54,6 +57,36 @@ class RegisterParticipantHistoricalDataViewModel @Inject constructor(
    val isEdit = mutableLiveData<Boolean>(false)
    val groupedVisitsByType = mutableLiveData<Map<String, List<VisitDetail>>>()
    val visitTypesData = mutableLiveData<MutableMap<String, HistoricalData>>(mutableMapOf())
+   private val _historicalVisitDates = MutableLiveData<List<DateTime>>(emptyList())
+   val historicalVisitDates: LiveData<List<DateTime>> get() = _historicalVisitDates
+   private val _disabledDates = MutableLiveData<MutableSet<Long>>().apply {
+      value = mutableSetOf()
+   }
+   private val disabledDates: LiveData<MutableSet<Long>> = _disabledDates
+   private val allDisabledDates = mutableSetOf<Long>()
+   fun getAllDisabledDates(): Set<Long> = allDisabledDates
+   private val _actionLiveData = MutableLiveData<String>()
+   val actionLiveData: LiveData<String> = _actionLiveData
+
+   private val disabledDatesByVisitType: MutableMap<String, Set<Long>> = mutableMapOf()
+
+   fun getDisabledDatesForVisitType(visitType: String): Set<Long> {
+      return disabledDatesByVisitType[visitType] ?: emptySet()
+   }
+
+   fun setDisabledDatesForVisitType(visitType: String, dates: Set<Long>) {
+      disabledDatesByVisitType[visitType] = dates
+   }
+
+   fun addDisabledDate(date: Long) {
+      allDisabledDates.add(date)
+   }
+
+   fun setAllDisabledDates(dates: Set<Long>) {
+      allDisabledDates.clear()
+      allDisabledDates.addAll(dates)
+   }
+
 
    init {
       participantSummaryArg
@@ -97,6 +130,18 @@ class RegisterParticipantHistoricalDataViewModel @Inject constructor(
          logError("Failed to get visits for participant: ", ex)
       }
    }
+
+   // Extension function to convert a Long timestamp to midnight time
+   private fun Long.toMidnight(): Long {
+      val cal = java.util.Calendar.getInstance()
+      cal.timeInMillis = this
+      cal.set(java.util.Calendar.HOUR_OF_DAY, 0)
+      cal.set(java.util.Calendar.MINUTE, 0)
+      cal.set(java.util.Calendar.SECOND, 0)
+      cal.set(java.util.Calendar.MILLISECOND, 0)
+      return cal.timeInMillis
+   }
+
 
    private fun buildHistoricalVisitObject(
       participant: ParticipantSummaryUiModel,
@@ -225,6 +270,7 @@ class RegisterParticipantHistoricalDataViewModel @Inject constructor(
       )
       currentData[visitTypeName] = updatedVisitTypeEntry
 
+
       visitTypesData.postValue(currentData)
    }
 
@@ -245,5 +291,11 @@ class RegisterParticipantHistoricalDataViewModel @Inject constructor(
       }
 
       return Date()
+   }
+
+   fun setHistoricalVisitDate(date: DateTime) {
+        _historicalVisitDates.value = _historicalVisitDates.value?.plus(date) ?: listOf(date)
+        Log.d("HistoricalVisit", "Set historical visit date: $date")
+
    }
 }


### PR DESCRIPTION
Here is what these changes Achieve, 
 At the point of registration when entering past visit, eg. 1-january-2025, This date becomes globally available and its disabled accross multiple visit types such that a user cannot select it again in the calendar.
 
 When you select same date at 6 weeks visit, you will see a message informing a user to choose a different date becuase this date has already been used and becomes **disabled**. Same thing cuts across all the visit types from **At birth** up to **2 year visit**
 
 Ideally you will not be able to add a date that has been added in one of the visit types. 