### PR TITLE
Buttons and back arrow button on the child matching page

### DIFF
--- a/app/src/main/java/com/jnj/vaccinetracker/participantflow/screens/ParticipantFlowMatchingAdapter.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/participantflow/screens/ParticipantFlowMatchingAdapter.kt
@@ -9,6 +9,10 @@ import com.jnj.vaccinetracker.databinding.ItemParticipantMatchingOtherSitePartic
 import com.jnj.vaccinetracker.databinding.ItemParticipantMatchingParticipantBinding
 import com.jnj.vaccinetracker.databinding.ItemParticipantMatchingSubtitleBinding
 
+/**
+ * @author maartenvangiel
+ * @version 1
+ */
 class ParticipantFlowMatchingAdapter(private val itemSelectedListener: (ParticipantFlowMatchingViewModel.MatchingListItem?) -> Unit) :
     RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
@@ -23,7 +27,7 @@ class ParticipantFlowMatchingAdapter(private val itemSelectedListener: (Particip
 
     fun updateItems(items: List<ParticipantFlowMatchingViewModel.MatchingListItem>) {
         this.items = items
-        selectedPosition = null 
+        selectedPosition = null
         notifyDataSetChanged()
     }
 

--- a/app/src/main/java/com/jnj/vaccinetracker/participantflow/screens/ParticipantFlowMatchingAdapter.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/participantflow/screens/ParticipantFlowMatchingAdapter.kt
@@ -23,7 +23,7 @@ class ParticipantFlowMatchingAdapter(private val itemSelectedListener: (Particip
 
     fun updateItems(items: List<ParticipantFlowMatchingViewModel.MatchingListItem>) {
         this.items = items
-        selectedPosition = null // Clear selection when items are updated
+        selectedPosition = null 
         notifyDataSetChanged()
     }
 

--- a/app/src/main/java/com/jnj/vaccinetracker/participantflow/screens/ParticipantFlowMatchingAdapter.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/participantflow/screens/ParticipantFlowMatchingAdapter.kt
@@ -9,11 +9,7 @@ import com.jnj.vaccinetracker.databinding.ItemParticipantMatchingOtherSitePartic
 import com.jnj.vaccinetracker.databinding.ItemParticipantMatchingParticipantBinding
 import com.jnj.vaccinetracker.databinding.ItemParticipantMatchingSubtitleBinding
 
-/**
- * @author maartenvangiel
- * @version 1
- */
-class ParticipantFlowMatchingAdapter(private val itemSelectedListener: (ParticipantFlowMatchingViewModel.MatchingListItem) -> Unit) :
+class ParticipantFlowMatchingAdapter(private val itemSelectedListener: (ParticipantFlowMatchingViewModel.MatchingListItem?) -> Unit) :
     RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     private companion object {
@@ -27,6 +23,7 @@ class ParticipantFlowMatchingAdapter(private val itemSelectedListener: (Particip
 
     fun updateItems(items: List<ParticipantFlowMatchingViewModel.MatchingListItem>) {
         this.items = items
+        selectedPosition = null // Clear selection when items are updated
         notifyDataSetChanged()
     }
 
@@ -62,10 +59,18 @@ class ParticipantFlowMatchingAdapter(private val itemSelectedListener: (Particip
 
     private fun onParticipantItemClicked(adapterPosition: Int) {
         val previousSelection = selectedPosition
-        selectedPosition = adapterPosition
-        previousSelection?.let { notifyItemChanged(it) }
-        notifyItemChanged(adapterPosition)
-        itemSelectedListener(items[adapterPosition])
+        if (selectedPosition == adapterPosition) {
+            // Deselect the currently selected item
+            selectedPosition = null
+            previousSelection?.let { notifyItemChanged(it) }
+            itemSelectedListener(null)
+        } else {
+            // Select the new item
+            selectedPosition = adapterPosition
+            previousSelection?.let { notifyItemChanged(it) }
+            notifyItemChanged(adapterPosition)
+            itemSelectedListener(items[adapterPosition])
+        }
     }
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
@@ -114,5 +119,4 @@ class ParticipantFlowMatchingAdapter(private val itemSelectedListener: (Particip
             binding.executePendingBindings()
         }
     }
-
 }

--- a/app/src/main/java/com/jnj/vaccinetracker/participantflow/screens/ParticipantFlowMatchingFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/participantflow/screens/ParticipantFlowMatchingFragment.kt
@@ -32,10 +32,6 @@ import com.jnj.vaccinetracker.visit.VisitActivity
 import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
-/**
- * @author maartenvangiel
- * @version 1
- */
 @RequiresApi(Build.VERSION_CODES.O)
 class ParticipantFlowMatchingFragment : BaseFragment() {
 
@@ -74,7 +70,7 @@ class ParticipantFlowMatchingFragment : BaseFragment() {
         }
 
         binding.btnReportAdverseEffects.setOnClickListener {
-            viewModel.getSelectedParticipantSummary()?.let {startParticipantReportAdverseEffects(it)}
+            viewModel.getSelectedParticipantSummary()?.let { startParticipantReportAdverseEffects(it) }
         }
         (activity as AppCompatActivity).supportActionBar?.setDisplayHomeAsUpEnabled(true)
         return binding.root
@@ -164,12 +160,18 @@ class ParticipantFlowMatchingFragment : BaseFragment() {
         (activity as AppCompatActivity).supportActionBar?.setDisplayHomeAsUpEnabled(!visible)
     }
 
-    private fun onItemSelected(matchingListItem: ParticipantFlowMatchingViewModel.MatchingListItem) {
-        val selectedParticipant = viewModel.setSelectedParticipant(matchingListItem)
-        if (selectedParticipant != null) {
-            flowViewModel.selectedParticipant.value = selectedParticipant
+    private fun onItemSelected(matchingListItem: ParticipantFlowMatchingViewModel.MatchingListItem?) {
+        if (matchingListItem == null) {
+            clearSelectedParticipant()
+        } else {
+            flowViewModel.selectedParticipant.value = viewModel.setSelectedParticipant(matchingListItem)
             setButtonsVisibility(true)
         }
+    }
+
+    fun clearSelectedParticipant() {
+        flowViewModel.selectedParticipant.value = null
+        setButtonsVisibility(false)
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
@@ -179,10 +181,8 @@ class ParticipantFlowMatchingFragment : BaseFragment() {
             Constants.REQ_REGISTER_PARTICIPANT -> {
                 val participant = data?.getParcelableExtra<ParticipantSummaryUiModel>(RegisterParticipantFlowActivity.EXTRA_PARTICIPANT)
                 if (participant == null) {
-                    // If no participant passed, we will return to the start of the identification flow
                     startActivity(ParticipantFlowActivity.create(requireContext()))
                 } else {
-                    // If participant passed, we continue
                     startParticipantVisitContraindications(participant, true)
                 }
                 requireActivity().finish()

--- a/app/src/main/java/com/jnj/vaccinetracker/participantflow/screens/ParticipantFlowMatchingFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/participantflow/screens/ParticipantFlowMatchingFragment.kt
@@ -32,6 +32,10 @@ import com.jnj.vaccinetracker.visit.VisitActivity
 import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
+/**
+ * @author maartenvangiel
+ * @version 1
+ */
 @RequiresApi(Build.VERSION_CODES.O)
 class ParticipantFlowMatchingFragment : BaseFragment() {
 
@@ -181,8 +185,10 @@ class ParticipantFlowMatchingFragment : BaseFragment() {
             Constants.REQ_REGISTER_PARTICIPANT -> {
                 val participant = data?.getParcelableExtra<ParticipantSummaryUiModel>(RegisterParticipantFlowActivity.EXTRA_PARTICIPANT)
                 if (participant == null) {
+                    // If no participant passed, we will return to the start of the identification flow
                     startActivity(ParticipantFlowActivity.create(requireContext()))
                 } else {
+                    // If participant passed, we continue
                     startParticipantVisitContraindications(participant, true)
                 }
                 requireActivity().finish()


### PR DESCRIPTION
This PR focuses on the 3 buttons and back arrow button on the child matching page

1. To make the back arrow disappear when a child is selected
2. The back arrow appears when a child is un-selected
3. To make the 3 buttons appear when a child is selected
4. To make the 3 buttons disappear when the child is un-selected