### PR TITLE
Remove new Added RegisteredDate Variable and use existing RegisteredDate

### DIFF
--- a/app/src/main/java/com/jnj/vaccinetracker/common/data/database/repositories/ParticipantRepository.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/common/data/database/repositories/ParticipantRepository.kt
@@ -53,7 +53,6 @@ class ParticipantRepository @Inject constructor(
             .withBirthWeight(birthWeight),
         biometricsTemplate = templateFile,
         image = imageFile,
-        registrationDate = dateModified,
     )
 
     private fun Participant.toPersistence() = ParticipantEntity(

--- a/app/src/main/java/com/jnj/vaccinetracker/common/domain/entities/Participant.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/common/domain/entities/Participant.kt
@@ -7,7 +7,6 @@ import com.jnj.vaccinetracker.common.data.database.typealiases.dateNow
 import com.jnj.vaccinetracker.common.data.models.Constants
 
 sealed class ParticipantBase {
-    abstract val registrationDate: DateEntity
     abstract val participantUuid: String
     abstract val nin: String?
     abstract val image: ParticipantImageFileBase?
@@ -51,15 +50,14 @@ data class Participant(
     override val attributes: Map<String, String>,
     override val address: Address?,
     override val childFirstName: String?,
-    override val childLastName: String?,
-    override val registrationDate: DateEntity
+    override val childLastName: String?
 ) : ParticipantBase(), SyncBase {
 
 }
 
 data class DraftParticipant(
     override val participantUuid: String,
-    override val registrationDate: DateEntity,
+    val registrationDate: DateEntity,
     override val image: DraftParticipantImageFile?,
     override val biometricsTemplate: DraftParticipantBiometricsTemplateFile?,
     override val participantId: String,
@@ -112,6 +110,5 @@ fun DraftParticipant.toParticipantWithoutAssets(): Participant = Participant(
     attributes = attributes,
     address = address,
     childFirstName = childFirstName,
-    childLastName = childLastName,
-    registrationDate = registrationDate
+    childLastName = childLastName
 )

--- a/app/src/main/java/com/jnj/vaccinetracker/common/domain/usecases/FindParticipantByParticipantUuidUseCase.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/common/domain/usecases/FindParticipantByParticipantUuidUseCase.kt
@@ -36,7 +36,6 @@ class FindParticipantByParticipantUuidUseCase @Inject constructor(
             address = address,
             childFirstName = childFirstName,
             childLastName = childLastName,
-            registrationDate = dateModified.date,
         )
     }
 

--- a/app/src/main/java/com/jnj/vaccinetracker/sync/domain/usecases/store/StoreParticipantSyncRecordUseCase.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/sync/domain/usecases/store/StoreParticipantSyncRecordUseCase.kt
@@ -54,7 +54,6 @@ class StoreParticipantSyncRecordUseCase @Inject constructor(
         address = address,
         childFirstName = childFirstName,
         childLastName = childLastName,
-        registrationDate = dateModified.date,
     )
 
     private suspend fun deleteUploadedDraftParticipant(participant: Participant) {

--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
@@ -60,32 +60,32 @@ class VisitsListViewModel @Inject constructor(
                 .filter { it.visitStatus == Constants.VISIT_STATUS_OCCURRED }
             Log.d("VisitsListViewModel", "Total visits retrieved: ${historicalVisits.size}")
 
-            // Filter visits based on visitDate >= registrationDate
-            val filteredVisits = historicalVisits.mapNotNull { visit ->
-                val participant = findParticipantByParticipantUuidUseCase.findByParticipantUuid(visit.participantUuid)
-                if (participant != null) {
-                    val registrationDate = participant.registrationDate
-                    val visitDate = visit.startDatetime
-
-                    if (visitDate >= registrationDate) {
-                        Log.d(
-                            "VisitsListViewModel",
-                            "Included visit: participantUuid=${visit.participantUuid}, visitDate=$visitDate, registrationDate=$registrationDate"
-                        )
-                        visit
-                    } else {
-                        Log.d(
-                            "VisitsListViewModel",
-                            "Excluded visit (visitDate < registrationDate): participantUuid=${visit.participantUuid}, visitDate=$visitDate, registrationDate=$registrationDate"
-                        )
-                        null
-                    }
-                } else {
-                    Log.w("VisitsListViewModel", "Participant not found for UUID: ${visit.participantUuid}")
-                    null
-                }
-            }
-            Log.d("VisitsListViewModel", "Filtered visits (visitDate >= registrationDate): ${filteredVisits.size}")
+//            // Filter visits based on visitDate >= registrationDate
+//            val filteredVisits = historicalVisits.mapNotNull { visit ->
+//                val participant = findParticipantByParticipantUuidUseCase.findByParticipantUuid(visit.participantUuid)
+//                if (participant != null) {
+//                    val registrationDate = participant.registrationDate
+//                    val visitDate = visit.startDatetime
+//
+//                    if (visitDate >= registrationDate) {
+//                        Log.d(
+//                            "VisitsListViewModel",
+//                            "Included visit: participantUuid=${visit.participantUuid}, visitDate=$visitDate, registrationDate=$registrationDate"
+//                        )
+//                        visit
+//                    } else {
+//                        Log.d(
+//                            "VisitsListViewModel",
+//                            "Excluded visit (visitDate < registrationDate): participantUuid=${visit.participantUuid}, visitDate=$visitDate, registrationDate=$registrationDate"
+//                        )
+//                        null
+//                    }
+//                } else {
+//                    Log.w("VisitsListViewModel", "Participant not found for UUID: ${visit.participantUuid}")
+//                    null
+//                }
+//            }
+//            Log.d("VisitsListViewModel", "Filtered visits (visitDate >= registrationDate): ${filteredVisits.size}")
 
             // Keep this section as-is
             val draftHistoricalVisits = draftVisitRepository.findVisitsBeforeDate(addDaysToDate(getTodayMidnight(), 1))
@@ -98,7 +98,7 @@ class VisitsListViewModel @Inject constructor(
                 convertDraftVisitEncounterToVisitOffline(draftVisitEncounter)
             }
 
-            val combinedVisits = convertedDraftVisits + convertedDraftVisitsEncounter + filteredVisits
+            val combinedVisits = convertedDraftVisits + convertedDraftVisitsEncounter + historicalVisits
             logInfo("Combined ${combinedVisits.size} visits into VisitDTOs")
 
             visitDTOs.value = createVisitDTOList(combinedVisits)


### PR DESCRIPTION
This PR focuses on removing the;

1. registration dates variables created
2. commenting out the registered children filter