### PR TITLE
 Visit Overview - Missed Visits - Should Save First Into Cache

### DIFF
--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
@@ -152,9 +152,15 @@ class VisitsListViewModel @Inject constructor(
             val convertedDraftVisitsEncounter = draftVisitsEncounter.map { draftVisitEncounter ->
                 convertDraftVisitEncounterToVisitOffline(draftVisitEncounter)
             }
-            
 
-            visitDTOs.value = createVisitDTOList(missedVisits)
+            val draftScheduledVisits = draftVisitRepository.findVisitsAfterDate(getTodayMidnight())
+            val filteredMissedVisits = missedVisits.filter { missedVisit ->
+                missedVisit.participantUuid !in draftScheduledVisits.map { it.participantUuid }
+            }
+
+            val combinedMissedVisits = convertedDraftVisits + convertedDraftVisitsEncounter + filteredMissedVisits
+
+            visitDTOs.value = createVisitDTOList(combinedMissedVisits)
             isLoading.value = false
         }
     }

--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
@@ -76,39 +76,39 @@ class VisitsListViewModel @Inject constructor(
                 .filter { it.visitStatus == Constants.VISIT_STATUS_OCCURRED }
             Log.d("VisitsListViewModel", "Total visits retrieved: ${historicalVisits.size}")
 
-            val filteredVisits = historicalVisits.mapNotNull { visit ->
-                val draftParticipant = draftParticipantRepository.findByParticipantUuid(visit.participantUuid)
-
-                if (draftParticipant != null) {
-                    val registrationDate = draftParticipant.registrationDate
-                    val visitDate = visit.startDatetime
-
-                    // remove time from date
-                    val removedVisitTime = removeTimeFromDateTime(visitDate)
-                    val removedRegistrationTime = removeTimeFromDateTime(registrationDate)
-
-                    val visitDateWithoutTime: LocalDate = LocalDate.parse(removedVisitTime)
-                    val registrationDateWithoutTime: LocalDate = LocalDate.parse(removedRegistrationTime)
-
-                    if (visitDateWithoutTime >= registrationDateWithoutTime) {
-                        Log.d(
-                            "VisitsListViewModel",
-                            "Included visit: participantUuid=${visit.participantUuid}, visitDate=$visitDateWithoutTime, registrationDate=$registrationDateWithoutTime"
-                        )
-                        visit
-                    } else {
-                        Log.d(
-                            "VisitsListViewModel",
-                            "Excluded visit (visitDate < registrationDate): participantUuid=${visit.participantUuid}, visitDate=$visitDateWithoutTime, registrationDate=$registrationDateWithoutTime"
-                        )
-                        null
-                    }
-                } else {
-                    Log.w("VisitsListViewModel", "Participant not found for UUID: ${visit.participantUuid}")
-                    null
-                }
-            }
-               Log.w("VisitsListViewModel", "Filtered visits: ${filteredVisits.size}")
+//            val filteredVisits = historicalVisits.mapNotNull { visit ->
+//                val draftParticipant = draftParticipantRepository.findByParticipantUuid(visit.participantUuid)
+//
+//                if (draftParticipant != null) {
+//                    val registrationDate = draftParticipant.registrationDate
+//                    val visitDate = visit.startDatetime
+//
+//                    // remove time from date
+//                    val removedVisitTime = removeTimeFromDateTime(visitDate)
+//                    val removedRegistrationTime = removeTimeFromDateTime(registrationDate)
+//
+//                    val visitDateWithoutTime: LocalDate = LocalDate.parse(removedVisitTime)
+//                    val registrationDateWithoutTime: LocalDate = LocalDate.parse(removedRegistrationTime)
+//
+//                    if (visitDateWithoutTime >= registrationDateWithoutTime) {
+//                        Log.d(
+//                            "VisitsListViewModel",
+//                            "Included visit: participantUuid=${visit.participantUuid}, visitDate=$visitDateWithoutTime, registrationDate=$registrationDateWithoutTime"
+//                        )
+//                        visit
+//                    } else {
+//                        Log.d(
+//                            "VisitsListViewModel",
+//                            "Excluded visit (visitDate < registrationDate): participantUuid=${visit.participantUuid}, visitDate=$visitDateWithoutTime, registrationDate=$registrationDateWithoutTime"
+//                        )
+//                        null
+//                    }
+//                } else {
+//                    Log.w("VisitsListViewModel", "Participant not found for UUID: ${visit.participantUuid}")
+//                    null
+//                }
+//            }
+//               Log.w("VisitsListViewModel", "Filtered visits: ${filteredVisits.size}")
 
             // Keep this section as-is
             val draftHistoricalVisits = draftVisitRepository.findVisitsBeforeDate(addDaysToDate(getTodayMidnight(), 1))
@@ -125,7 +125,7 @@ class VisitsListViewModel @Inject constructor(
                 draftVisitEncounter.participantUuid !in convertedDraftVisits.map { it.participantUuid }
             }
 
-            val combinedVisits = convertedDraftVisits + filteredDraftVisitsEncounter + filteredVisits
+            val combinedVisits = convertedDraftVisits + filteredDraftVisitsEncounter + historicalVisits
 
             logInfo("Combined ${combinedVisits.size} visits into VisitDTOs")
 

--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
@@ -147,6 +147,11 @@ class VisitsListViewModel @Inject constructor(
             val convertedDraftVisits = draftVisits.map { draftVisit ->
                 convertDraftVisitToVisitOffline(draftVisit)
             }
+
+            val draftVisitsEncounter = draftVisitEncounterRepository.findVisitsBeforeDate(getTodayMidnight())
+            val convertedDraftVisitsEncounter = draftVisitsEncounter.map { draftVisitEncounter ->
+                convertDraftVisitEncounterToVisitOffline(draftVisitEncounter)
+            }
             
 
             visitDTOs.value = createVisitDTOList(missedVisits)

--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
@@ -101,6 +101,34 @@ class VisitsListViewModel @Inject constructor(
         }
     }
 
+    fun getMissedVisitsData() {
+        isLoading.value = true
+        viewModelScope.launch {
+            val missedVisits = visitRepository.findVisitsBeforeDate(getTodayMidnight())
+                .filter { it.visitStatus == Constants.VISIT_STATUS_SCHEDULED }
+
+            val draftVisits = draftVisitRepository.findVisitsBeforeDate(getTodayMidnight())
+            val convertedDraftVisits = draftVisits.map { draftVisit ->
+                convertDraftVisitToVisitOffline(draftVisit)
+            }
+
+            val draftVisitsEncounter = draftVisitEncounterRepository.findVisitsBeforeDate(getTodayMidnight())
+            val convertedDraftVisitsEncounter = draftVisitsEncounter.map { draftVisitEncounter ->
+                convertDraftVisitEncounterToVisitOffline(draftVisitEncounter)
+            }
+
+            val combinedMissedVisits = convertedDraftVisits + convertedDraftVisitsEncounter + missedVisits
+
+            val draftScheduledVisits = draftVisitRepository.findVisitsAfterDate(getTodayMidnight())
+            val filteredMissedVisits = combinedMissedVisits.filter { missedVisit ->
+                missedVisit.participantUuid !in draftScheduledVisits.map { it.participantUuid }
+            }
+
+            visitDTOs.value = createVisitDTOList(filteredMissedVisits)
+            isLoading.value = false
+        }
+    }
+
     // Registration date filter function
     @RequiresApi(Build.VERSION_CODES.O)
     suspend fun filterVisitsByRegistrationDate(visits: List<Visit>): List<Visit> {
@@ -128,34 +156,6 @@ class VisitsListViewModel @Inject constructor(
                 Log.d("VisitsListViewModel", "Participant not found for UUID: ${visit.participantUuid}")
                 null
             }
-        }
-    }
-
-    fun getMissedVisitsData() {
-        isLoading.value = true
-        viewModelScope.launch {
-            val missedVisits = visitRepository.findVisitsBeforeDate(getTodayMidnight())
-                .filter { it.visitStatus == Constants.VISIT_STATUS_SCHEDULED }
-
-            val draftVisits = draftVisitRepository.findVisitsBeforeDate(getTodayMidnight())
-            val convertedDraftVisits = draftVisits.map { draftVisit ->
-                convertDraftVisitToVisitOffline(draftVisit)
-            }
-
-            val draftVisitsEncounter = draftVisitEncounterRepository.findVisitsBeforeDate(getTodayMidnight())
-            val convertedDraftVisitsEncounter = draftVisitsEncounter.map { draftVisitEncounter ->
-                convertDraftVisitEncounterToVisitOffline(draftVisitEncounter)
-            }
-
-            val combinedMissedVisits = convertedDraftVisits + convertedDraftVisitsEncounter + missedVisits
-
-            val draftScheduledVisits = draftVisitRepository.findVisitsAfterDate(getTodayMidnight())
-            val filteredMissedVisits = combinedMissedVisits.filter { missedVisit ->
-                missedVisit.participantUuid !in draftScheduledVisits.map { it.participantUuid }
-            }
-
-            visitDTOs.value = createVisitDTOList(filteredMissedVisits)
-            isLoading.value = false
         }
     }
 

--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
@@ -137,6 +137,23 @@ class VisitsListViewModel @Inject constructor(
         }
     }
 
+    fun getMissedVisitsData() {
+        isLoading.value = true
+        viewModelScope.launch {
+            val missedVisits = visitRepository.findVisitsBeforeDate(getTodayMidnight())
+                .filter { it.visitStatus == Constants.VISIT_STATUS_SCHEDULED }
+
+            val draftVisits = draftVisitRepository.findVisitsBeforeDate(getTodayMidnight())
+            val convertedDraftVisits = draftVisits.map { draftVisit ->
+                convertDraftVisitToVisitOffline(draftVisit)
+            }
+            
+
+            visitDTOs.value = createVisitDTOList(missedVisits)
+            isLoading.value = false
+        }
+    }
+
     private fun convertDraftVisitToVisitOffline(draftVisit: DraftVisit): Visit {
         return Visit(
             visitUuid = draftVisit.visitUuid,
@@ -160,16 +177,6 @@ class VisitsListViewModel @Inject constructor(
                 ObservationValue(entry.value, draftVisitEncounter.startDatetime)
             },
             dateModified = Date(System.currentTimeMillis()))
-    }
-
-    fun getMissedVisitsData() {
-        isLoading.value = true
-        viewModelScope.launch {
-            val missedVisits = visitRepository.findVisitsBeforeDate(getTodayMidnight())
-                .filter { it.visitStatus == Constants.VISIT_STATUS_SCHEDULED }
-            visitDTOs.value = createVisitDTOList(missedVisits)
-            isLoading.value = false
-        }
     }
 
     private suspend fun createVisitDTOList(visits: List<Visit>): List<VisitDataDTO> {

--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
@@ -153,14 +153,14 @@ class VisitsListViewModel @Inject constructor(
                 convertDraftVisitEncounterToVisitOffline(draftVisitEncounter)
             }
 
+            val combinedMissedVisits = convertedDraftVisits + convertedDraftVisitsEncounter + missedVisits
+
             val draftScheduledVisits = draftVisitRepository.findVisitsAfterDate(getTodayMidnight())
-            val filteredMissedVisits = missedVisits.filter { missedVisit ->
+            val filteredMissedVisits = combinedMissedVisits.filter { missedVisit ->
                 missedVisit.participantUuid !in draftScheduledVisits.map { it.participantUuid }
             }
 
-            val combinedMissedVisits = convertedDraftVisits + convertedDraftVisitsEncounter + filteredMissedVisits
-
-            visitDTOs.value = createVisitDTOList(combinedMissedVisits)
+            visitDTOs.value = createVisitDTOList(filteredMissedVisits)
             isLoading.value = false
         }
     }

--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
@@ -71,46 +71,14 @@ class VisitsListViewModel @Inject constructor(
     fun getHistoricalVisitsData() {
         isLoading.value = true
         viewModelScope.launch {
-
             val historicalVisits = visitRepository.findVisitsBeforeDate(addDaysToDate(getTodayMidnight(), 1))
                 .filter { it.visitStatus == Constants.VISIT_STATUS_OCCURRED }
             Log.d("VisitsListViewModel", "Total visits retrieved: ${historicalVisits.size}")
 
-//            val filteredVisits = historicalVisits.mapNotNull { visit ->
-//                val draftParticipant = draftParticipantRepository.findByParticipantUuid(visit.participantUuid)
-//
-//                if (draftParticipant != null) {
-//                    val registrationDate = draftParticipant.registrationDate
-//                    val visitDate = visit.startDatetime
-//
-//                    // remove time from date
-//                    val removedVisitTime = removeTimeFromDateTime(visitDate)
-//                    val removedRegistrationTime = removeTimeFromDateTime(registrationDate)
-//
-//                    val visitDateWithoutTime: LocalDate = LocalDate.parse(removedVisitTime)
-//                    val registrationDateWithoutTime: LocalDate = LocalDate.parse(removedRegistrationTime)
-//
-//                    if (visitDateWithoutTime >= registrationDateWithoutTime) {
-//                        Log.d(
-//                            "VisitsListViewModel",
-//                            "Included visit: participantUuid=${visit.participantUuid}, visitDate=$visitDateWithoutTime, registrationDate=$registrationDateWithoutTime"
-//                        )
-//                        visit
-//                    } else {
-//                        Log.d(
-//                            "VisitsListViewModel",
-//                            "Excluded visit (visitDate < registrationDate): participantUuid=${visit.participantUuid}, visitDate=$visitDateWithoutTime, registrationDate=$registrationDateWithoutTime"
-//                        )
-//                        null
-//                    }
-//                } else {
-//                    Log.w("VisitsListViewModel", "Participant not found for UUID: ${visit.participantUuid}")
-//                    null
-//                }
-//            }
-//               Log.w("VisitsListViewModel", "Filtered visits: ${filteredVisits.size}")
+//            Filter historical visits by registration date
+//            val filteredVisits = filterVisitsByRegistrationDate(historicalVisits)
+//            Log.d("VisitsListViewModel", "Filtered visits: ${filteredVisits.size}")
 
-            // Keep this section as-is
             val draftHistoricalVisits = draftVisitRepository.findVisitsBeforeDate(addDaysToDate(getTodayMidnight(), 1))
             val convertedDraftVisits = draftHistoricalVisits.map { draftVisit ->
                 convertDraftVisitToVisitOffline(draftVisit)
@@ -126,14 +94,40 @@ class VisitsListViewModel @Inject constructor(
             }
 
             val combinedVisits = convertedDraftVisits + filteredDraftVisitsEncounter + historicalVisits
-
-            logInfo("Combined ${combinedVisits.size} visits into VisitDTOs")
+            Log.d("VisitsListViewModel", "Draft visit ${convertedDraftVisits.size}, Draft visits encounter ${filteredDraftVisitsEncounter.size}, Historical visits ${historicalVisits.size}, Combined visits: ${combinedVisits.size}")
 
             visitDTOs.value = createVisitDTOList(combinedVisits)
-            Log.w("VisitsListViewModel", "Filtered visits: ${combinedVisits.size}")
-
             isLoading.value = false
+        }
+    }
 
+    // Registration date filter function
+    @RequiresApi(Build.VERSION_CODES.O)
+    suspend fun filterVisitsByRegistrationDate(visits: List<Visit>): List<Visit> {
+        return visits.mapNotNull { visit ->
+            val draftParticipant = draftParticipantRepository.findByParticipantUuid(visit.participantUuid)
+            if (draftParticipant != null) {
+                val registrationDate = draftParticipant.registrationDate
+                val visitDate = visit.startDatetime
+
+                // remove time from date
+                val removedVisitTime = removeTimeFromDateTime(visitDate)
+                val removedRegistrationTime = removeTimeFromDateTime(registrationDate)
+
+                val visitDateWithoutTime: LocalDate = LocalDate.parse(removedVisitTime)
+                val registrationDateWithoutTime: LocalDate = LocalDate.parse(removedRegistrationTime)
+
+                if (visitDateWithoutTime >= registrationDateWithoutTime) {
+                    Log.d("VisitsListViewModel", "Included visit: participantUuid=${visit.participantUuid}, visitDate=$visitDateWithoutTime, registrationDate=$registrationDateWithoutTime")
+                    visit
+                } else {
+                    Log.d("VisitsListViewModel", "Excluded visit (visitDate < registrationDate): participantUuid=${visit.participantUuid}, visitDate=$visitDateWithoutTime, registrationDate=$registrationDateWithoutTime")
+                    null
+                }
+            } else {
+                Log.d("VisitsListViewModel", "Participant not found for UUID: ${visit.participantUuid}")
+                null
+            }
         }
     }
 


### PR DESCRIPTION
This PR focuses on;

1. Adding a missed visit for a child into the missed visit report while system is offline
2. Removing a missed visit from the missed visit report to the visit history report  immediately when the child has been vaccinated while system is offline
3. Creating a scheduled visit for the child while system is offline