### PR TITLE
Adding location filter to vaccines report

### DIFF
--- a/app/src/main/java/com/jnj/vaccinetracker/reportsoverview/vaccinesoverview/model/VaccinesOverviewViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/reportsoverview/vaccinesoverview/model/VaccinesOverviewViewModel.kt
@@ -149,10 +149,10 @@ class VaccinesOverviewViewModel @Inject constructor(
     private suspend fun participantFromCurrentLocation(visit: Visit, locationUuid: String?): Boolean {
         val participant = findParticipantByParticipantUuidUseCase.findByParticipantUuid(visit.participantUuid)
         return if (participant == null) {
-            Log.w("VaccinesiewModel", "Participant not found for UUID: ${visit.participantUuid}")
+            Log.w("VaccinesiewModel", "Participant not found")
             false
         } else {
-            Log.d("VaccinesViewModel", "Participant found: ${participant.participantUuid}, Location UUID: ${participant.locationUuid} vs Current Location UUID: $locationUuid")
+            Log.d("VaccinesViewModel", "Participant found")
             participant.locationUuid == locationUuid
         }
     }

--- a/app/src/main/java/com/jnj/vaccinetracker/reportsoverview/vaccinesoverview/model/VaccinesOverviewViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/reportsoverview/vaccinesoverview/model/VaccinesOverviewViewModel.kt
@@ -1,6 +1,7 @@
 package com.jnj.vaccinetracker.reportsoverview.vaccinesoverview.model
 
 import android.os.Bundle
+import android.util.Log
 import androidx.annotation.StringRes
 import androidx.lifecycle.viewModelScope
 import com.jnj.vaccinetracker.R
@@ -11,6 +12,7 @@ import com.jnj.vaccinetracker.common.data.database.typealiases.getTodayMidnight
 import com.jnj.vaccinetracker.common.data.managers.ConfigurationManager
 import com.jnj.vaccinetracker.common.data.models.Constants
 import com.jnj.vaccinetracker.common.data.models.NavigationDirection
+import com.jnj.vaccinetracker.common.data.repositories.UserRepository
 import com.jnj.vaccinetracker.common.domain.entities.BirthDate
 import com.jnj.vaccinetracker.common.domain.entities.DraftVisitEncounter
 import com.jnj.vaccinetracker.common.domain.entities.ObservationValue
@@ -27,6 +29,7 @@ import java.util.Date
 import javax.inject.Inject
 
 class VaccinesOverviewViewModel @Inject constructor(
+    userRepository: UserRepository,
     private val configurationManager: ConfigurationManager,
     private val visitRepository: VisitRepository,
     private val draftVisitEncounterRepository: DraftVisitEncounterRepository,
@@ -39,6 +42,7 @@ class VaccinesOverviewViewModel @Inject constructor(
     var navigationDirection = NavigationDirection.NONE
     private var screens = listOf<Screen>()
     val isLoading = mutableLiveData<Boolean>()
+    private val currentLocationUuid = userRepository.getDeviceNameSiteUuid()
 
     init {
         initScreens()
@@ -51,7 +55,7 @@ class VaccinesOverviewViewModel @Inject constructor(
     fun getVaccinesData() {
         isLoading.value = true
         viewModelScope.launch {
-            val occurredVisits = visitRepository.findAllVisitsByAttributeTypeAndValue(Constants.ATTRIBUTE_VISIT_STATUS, Constants.VISIT_STATUS_OCCURRED)
+            val occurredVisits = visitRepository.findAllVisitsByAttributeTypeAndValue(Constants.ATTRIBUTE_VISIT_STATUS, Constants.VISIT_STATUS_OCCURRED).filter { participantFromCurrentLocation(it, currentLocationUuid) }
 
             val draftVisitEncounters = draftVisitEncounterRepository.findVisitsBeforeDate(addDaysToDate(getTodayMidnight(), 1))
             val draftVisitEncountersAsVisits = draftVisitEncounters.map { convertDraftVisitEncounterToVisit(it) }
@@ -139,6 +143,17 @@ class VaccinesOverviewViewModel @Inject constructor(
         if (currentScreen.get() == null) {
             val screen = screens.firstOrNull()
             currentScreen.set(screen)
+        }
+    }
+
+    private suspend fun participantFromCurrentLocation(visit: Visit, locationUuid: String?): Boolean {
+        val participant = findParticipantByParticipantUuidUseCase.findByParticipantUuid(visit.participantUuid)
+        return if (participant == null) {
+            Log.w("VaccinesiewModel", "Participant not found for UUID: ${visit.participantUuid}")
+            false
+        } else {
+            Log.d("VaccinesViewModel", "Participant found: ${participant.participantUuid}, Location UUID: ${participant.locationUuid} vs Current Location UUID: $locationUuid")
+            participant.locationUuid == locationUuid
         }
     }
 


### PR DESCRIPTION
This PR focuses on adding a location filter attribute to the vaccine reports such that the vaccine report shows vaccine that belong to only this current facility