### PR TITLE
Update on when the out of dosing window popup appears

### DIFF
--- a/app/src/main/java/com/jnj/vaccinetracker/visit/dialog/DosingOutOfWindowDialog.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visit/dialog/DosingOutOfWindowDialog.kt
@@ -18,6 +18,16 @@ class DosingOutOfWindowDialog : BaseDialogFragment() {
 
     private lateinit var binding: DialogDosingOutOfWindowBinding
 
+    companion object {
+        fun newInstance(showConfirmButton: Boolean): DosingOutOfWindowDialog {
+            val args = Bundle()
+            args.putBoolean("showConfirmButton", showConfirmButton)
+            val dialog = DosingOutOfWindowDialog()
+            dialog.arguments = args
+            return dialog
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setStyle(STYLE_NO_TITLE, 0)
@@ -27,6 +37,10 @@ class DosingOutOfWindowDialog : BaseDialogFragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         binding = DataBindingUtil.inflate(inflater, R.layout.dialog_dosing_out_of_window, container, false)
         binding.executePendingBindings()
+
+        val showConfirm = arguments?.getBoolean("showConfirmButton") ?: true
+        binding.btnConfirm.visibility = if (showConfirm) View.VISIBLE else View.GONE
+
         binding.btnConfirm.setOnClickListener {
             dismissAllowingStateLoss()
         }
@@ -40,5 +54,4 @@ class DosingOutOfWindowDialog : BaseDialogFragment() {
     interface DosingOutOfWindowDialogListener {
         fun onOutOfWindowDosingCanceled()
     }
-
 }

--- a/app/src/main/java/com/jnj/vaccinetracker/visit/dialog/DosingOutOfWindowDialog.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visit/dialog/DosingOutOfWindowDialog.kt
@@ -19,19 +19,14 @@ class DosingOutOfWindowDialog : BaseDialogFragment() {
     private lateinit var binding: DialogDosingOutOfWindowBinding
 
     companion object {
-        fun newInstance(showConfirmButton: Boolean): DosingOutOfWindowDialog {
+        fun newInstance(showConfirmButton: Boolean, descriptionResId: Int): DosingOutOfWindowDialog {
             val args = Bundle()
             args.putBoolean("showConfirmButton", showConfirmButton)
+            args.putInt("descriptionResId", descriptionResId)
             val dialog = DosingOutOfWindowDialog()
             dialog.arguments = args
             return dialog
         }
-    }
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        setStyle(STYLE_NO_TITLE, 0)
-        isCancelable = false
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
@@ -39,11 +34,12 @@ class DosingOutOfWindowDialog : BaseDialogFragment() {
         binding.executePendingBindings()
 
         val showConfirm = arguments?.getBoolean("showConfirmButton") ?: true
-        binding.btnConfirm.visibility = if (showConfirm) View.VISIBLE else View.GONE
+        val descriptionResId = arguments?.getInt("descriptionResId") ?: R.string.visit_dosing_warning_out_of_time_window_description
 
-        binding.btnConfirm.setOnClickListener {
-            dismissAllowingStateLoss()
-        }
+        binding.btnConfirm.visibility = if (showConfirm) View.VISIBLE else View.GONE
+        binding.textViewDescription.setText(descriptionResId)
+
+        binding.btnConfirm.setOnClickListener { dismissAllowingStateLoss() }
         binding.btnCancel.setOnClickListener {
             dismissAllowingStateLoss()
             findParent<DosingOutOfWindowDialogListener>()?.onOutOfWindowDosingCanceled()

--- a/app/src/main/java/com/jnj/vaccinetracker/visit/screens/ContraindicationsFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visit/screens/ContraindicationsFragment.kt
@@ -132,7 +132,8 @@ class ContraindicationsFragment : BaseFragment() {
    }
 
     private fun showFarFromWindowDialog() {
-       Log.d("OutOfWindow", "showFarFromWindowDialog called")
+        val dialog = DosingOutOfWindowDialog.newInstance(false)
+        dialog.show(requireActivity().supportFragmentManager, "TAG_DOSING_OUT_OF_WINDOW")
     }
 }
 

--- a/app/src/main/java/com/jnj/vaccinetracker/visit/screens/ContraindicationsFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visit/screens/ContraindicationsFragment.kt
@@ -2,6 +2,7 @@ package com.jnj.vaccinetracker.visit.screens
 
 import android.os.Build
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -19,6 +20,8 @@ import com.jnj.vaccinetracker.visit.VisitActivity
 import com.jnj.vaccinetracker.visit.VisitViewModel
 import com.jnj.vaccinetracker.visit.dialog.DosingOutOfWindowDialog
 import com.jnj.vaccinetracker.visit.dialog.RescheduleVisitDialog
+import java.util.Calendar
+import kotlin.math.ceil
 
 @RequiresApi(Build.VERSION_CODES.O)
 class ContraindicationsFragment : BaseFragment() {
@@ -50,18 +53,45 @@ class ContraindicationsFragment : BaseFragment() {
       }
    }
 
-   private fun setupClickListeners() {
-      binding.btnYes.setOnClickListener {
-         showRescheduleVisitDialog()
-      }
+   // ===================================================
+// ===================================================
 
-      binding.btnNo.setOnClickListener {
-         closeFragment()
-         if (!viewModel.dosingVisitIsInsideTimeWindow.value) {
-            showOutsideTimeWindowConfirmationDialog()
-         }
-      }
-   }
+   // ===================================================
+    private fun setupClickListeners() {
+        binding.btnYes.setOnClickListener {
+            showRescheduleVisitDialog()
+        }
+
+        binding.btnNo.setOnClickListener {
+            closeFragment()
+            val visitDate = viewModel.dosingVisit.value?.visitDate
+            if (visitDate != null) {
+                val todayCal = Calendar.getInstance().apply {
+                    set(Calendar.HOUR_OF_DAY, 0)
+                    set(Calendar.MINUTE, 0)
+                    set(Calendar.SECOND, 0)
+                    set(Calendar.MILLISECOND, 0)
+                }
+                val visitCal = Calendar.getInstance().apply {
+                    time = visitDate
+                    set(Calendar.HOUR_OF_DAY, 0)
+                    set(Calendar.MINUTE, 0)
+                    set(Calendar.SECOND, 0)
+                    set(Calendar.MILLISECOND, 0)
+                }
+                val diffMillis = visitCal.timeInMillis - todayCal.timeInMillis
+                val daysToVisitDate = ceil(diffMillis / (1000.0 * 60 * 60 * 24)).toInt()
+                when {
+                    daysToVisitDate in 1..5 -> showOutsideTimeWindowConfirmationDialog()
+                    daysToVisitDate > 5 -> showFarFromWindowDialog()
+                }
+            }
+        }
+    }
+   // ===================================================
+// ===================================================
+// ===================================================
+
    private fun showRescheduleVisitDialog() {
       RescheduleVisitDialog.create(participant = viewModel.participant.value, isAfterContraIndications = true)
          .show(parentFragmentManager, RescheduleVisitDialog.TAG_DIALOG_RESCHEDULE_VISIT)
@@ -101,5 +131,9 @@ class ContraindicationsFragment : BaseFragment() {
          VisitActivity.TAG_DIALOG_DOSING_OUT_OF_WINDOW
       )
    }
+
+    private fun showFarFromWindowDialog() {
+       Log.d("OutOfWindow", "showFarFromWindowDialog called")
+    }
 }
 

--- a/app/src/main/java/com/jnj/vaccinetracker/visit/screens/ContraindicationsFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visit/screens/ContraindicationsFragment.kt
@@ -118,14 +118,20 @@ class ContraindicationsFragment : BaseFragment() {
          .commit()
    }
 
-   private fun showOutsideTimeWindowConfirmationDialog() {
-       val dialog = DosingOutOfWindowDialog.newInstance(true)
-       dialog.show(requireActivity().supportFragmentManager, VisitActivity.TAG_DIALOG_DOSING_OUT_OF_WINDOW)
-   }
-
-    private fun showFarFromWindowDialog() {
-        val dialog = DosingOutOfWindowDialog.newInstance(false)
-        dialog.show(requireActivity().supportFragmentManager, "TAG_DOSING_OUT_OF_WINDOW")
+    private fun showOutsideTimeWindowConfirmationDialog() {
+        val dialog = DosingOutOfWindowDialog.newInstance(
+            true,
+            R.string.visit_dosing_warning_out_of_time_window_description
+        )
+        dialog.show(requireActivity().supportFragmentManager, VisitActivity.TAG_DIALOG_DOSING_OUT_OF_WINDOW)
     }
+
+   private fun showFarFromWindowDialog() {
+       val dialog = DosingOutOfWindowDialog.newInstance(
+           false,
+           R.string.visit_dosing_warning_far_from_time_window_description
+       )
+       dialog.show(requireActivity().supportFragmentManager, "TAG_DOSING_OUT_OF_WINDOW")
+   }
 }
 

--- a/app/src/main/java/com/jnj/vaccinetracker/visit/screens/ContraindicationsFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visit/screens/ContraindicationsFragment.kt
@@ -2,7 +2,6 @@ package com.jnj.vaccinetracker.visit.screens
 
 import android.os.Build
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -53,10 +52,6 @@ class ContraindicationsFragment : BaseFragment() {
       }
    }
 
-   // ===================================================
-// ===================================================
-
-   // ===================================================
     private fun setupClickListeners() {
         binding.btnYes.setOnClickListener {
             showRescheduleVisitDialog()
@@ -88,9 +83,6 @@ class ContraindicationsFragment : BaseFragment() {
             }
         }
     }
-   // ===================================================
-// ===================================================
-// ===================================================
 
    private fun showRescheduleVisitDialog() {
       RescheduleVisitDialog.create(participant = viewModel.participant.value, isAfterContraIndications = true)

--- a/app/src/main/java/com/jnj/vaccinetracker/visit/screens/ContraindicationsFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visit/screens/ContraindicationsFragment.kt
@@ -127,9 +127,8 @@ class ContraindicationsFragment : BaseFragment() {
    }
 
    private fun showOutsideTimeWindowConfirmationDialog() {
-      DosingOutOfWindowDialog().show(requireActivity().supportFragmentManager,
-         VisitActivity.TAG_DIALOG_DOSING_OUT_OF_WINDOW
-      )
+       val dialog = DosingOutOfWindowDialog.newInstance(true)
+       dialog.show(requireActivity().supportFragmentManager, VisitActivity.TAG_DIALOG_DOSING_OUT_OF_WINDOW)
    }
 
     private fun showFarFromWindowDialog() {

--- a/app/src/main/res/layout/dialog_dosing_out_of_window.xml
+++ b/app/src/main/res/layout/dialog_dosing_out_of_window.xml
@@ -5,22 +5,21 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/constraintLayout"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:padding="16dp">
 
         <ImageView
             android:id="@+id/img_header"
             android:layout_width="0dp"
             android:layout_height="120dp"
-            android:background="@color/alertLight"
-            android:gravity="center"
-            android:paddingTop="30dp"
-            android:paddingBottom="30dp"
             android:scaleType="fitCenter"
+            android:adjustViewBounds="true"
+            android:background="@color/alertLight"
             android:src="@drawable/ic_checkmark_alert"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
+            app:tint="@color/colorTextOnPrimary"
             app:layout_constraintTop_toTopOf="parent"
-            app:tint="@color/colorTextOnPrimary" />
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
 
         <TextView
             android:id="@+id/textView_title"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -229,7 +229,7 @@
     <string name="visit_schedule_visit_saved_successfully_label">Next visit successfully registered on: </string>
     <string name="visit_schedule_visit_failed">Saving visit failed</string>
     <string name="visit_dosing_warning_out_of_time_window_description">Please confirm that this child is receiving a dosage before the scheduled date.</string>
-    <string name="visit_dosing_warning_far_from_time_window_description">Please note that this child is not due the for the next visit.</string>
+    <string name="visit_dosing_warning_far_from_time_window_description">Please note that this child is not due for the next visit.</string>
     <string name="visit_dosing_warning_out_of_time_window_title">Dosing outside of window</string>
     <string name="visit_dosing_error_different_manufacturer_description">The manufacturer selected is different from the one indicated in the regimen and should not be administered.</string>
     <string name="visit_dosing_warning_different_manufacturer_description">The manufacturer selected is different from the one indicated in the regimen. Please confirm you will administer a different vaccine.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -228,7 +228,8 @@
     <string name="visit_schedule_next_visit_save_visit_button_label">Save Visit</string>
     <string name="visit_schedule_visit_saved_successfully_label">Next visit successfully registered on: </string>
     <string name="visit_schedule_visit_failed">Saving visit failed</string>
-    <string name="visit_dosing_warning_out_of_time_window_description">Please confirm that this Child is receiving a dosage outside of the indicated time window.</string>
+    <string name="visit_dosing_warning_out_of_time_window_description">Please confirm that this child is receiving a dosage before the scheduled date.</string>
+    <string name="visit_dosing_warning_far_from_time_window_description">Please note that this child is not due the for the next visit.</string>
     <string name="visit_dosing_warning_out_of_time_window_title">Dosing outside of window</string>
     <string name="visit_dosing_error_different_manufacturer_description">The manufacturer selected is different from the one indicated in the regimen and should not be administered.</string>
     <string name="visit_dosing_warning_different_manufacturer_description">The manufacturer selected is different from the one indicated in the regimen. Please confirm you will administer a different vaccine.</string>


### PR DESCRIPTION
# This PR focuses on

1. Making the `out of dosing window pop up not to appear` after the scheduled visit date
2. Make the pop up appear `with the confirm button` if the visit date is within 5 days to the scheduled date
3.  Make the pop up appear `without` the confirm button` if the visit date is within 5 days to the scheduled date 
4. To change the wording on the pop up depending on when the pop up is displayed
5. To improve the dialog xml to adopt to different amount of words on the pop up