### PR TITLE
Past Visit Date Validation

### DIFF
--- a/app/src/main/java/com/jnj/vaccinetracker/register/dialogs/HistoricalVisitDateDialog.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/register/dialogs/HistoricalVisitDateDialog.kt
@@ -138,45 +138,47 @@ class HistoricalVisitDateDialog : BaseDialogFragment() {
       logDisabledDates()
 
       datePicker.setOnDateChangedListener { _, year, month, day ->
-         val selectedCalendar = Calendar.getInstance()
-         selectedCalendar.set(year, month, day, 0, 0, 0)
-         selectedCalendar.set(Calendar.MILLISECOND, 0)
-         val selectedDateMillis = selectedCalendar.timeInMillis
+          val selectedCalendar = Calendar.getInstance()
+          selectedCalendar.set(year, month, day, 0, 0, 0)
+          selectedCalendar.set(Calendar.MILLISECOND, 0)
+          val selectedDateMillis = selectedCalendar.timeInMillis
+          val visitType = arguments?.getString(VISIT_TYPE) ?: ""
+          val selectedDate = DateTime(year, month + 1, day)
 
-         val visitType = arguments?.getString(VISIT_TYPE) ?: ""
+          // Chronological order validation
+          val isChronologicalValid = viewModel.isHistoricalVisitDateValid(selectedDate)
+          val error = viewModel.errorMessage.value
 
-           val selectedDate = DateTime(year, month + 1, day)
-           viewModel.setHistoricalVisitDate(selectedDate)
-           val error = viewModel.errorMessage.value
-
-           if (!error.isNullOrEmpty()) {
-               Toast.makeText(requireContext(), error, Toast.LENGTH_SHORT).show()
-               Log.d("DatePicker", "Selected date is invalid: $error")
-               lastValidDate?.let {
-                   val resetCalendar = Calendar.getInstance()
-                   resetCalendar.timeInMillis = it
-                   datePicker.updateDate(
-                       resetCalendar.get(Calendar.YEAR),
-                       resetCalendar.get(Calendar.MONTH),
-                       resetCalendar.get(Calendar.DAY_OF_MONTH)
-                   )
-               }
-           } else if (visitType != "At Birth" && disabledDates.contains(selectedDateMillis)) {
-            Toast.makeText(requireContext(), "This date is already used. Please select another.", Toast.LENGTH_SHORT).show()
-            Log.d("DatePicker", "Selected date is disabled")
-            lastValidDate?.let {
-               val resetCalendar = Calendar.getInstance()
-               resetCalendar.timeInMillis = it
-               datePicker.updateDate(
-                  resetCalendar.get(Calendar.YEAR),
-                  resetCalendar.get(Calendar.MONTH),
-                  resetCalendar.get(Calendar.DAY_OF_MONTH)
-               )
-            }
-         } else {
-            Log.d("DatePicker", "Selected date is valid")
-            lastValidDate = selectedDateMillis
-         }
+          if (!isChronologicalValid && !error.isNullOrEmpty()) {
+              Toast.makeText(requireContext(), error, Toast.LENGTH_SHORT).show()
+              Log.d("DatePicker", "Selected date is invalid: $error")
+              viewModel.clearErrorMessage()
+              lastValidDate?.let {
+                  val resetCalendar = Calendar.getInstance()
+                  resetCalendar.timeInMillis = it
+                  datePicker.updateDate(
+                      resetCalendar.get(Calendar.YEAR),
+                      resetCalendar.get(Calendar.MONTH),
+                      resetCalendar.get(Calendar.DAY_OF_MONTH)
+                  )
+              }
+          } else if (visitType != "At Birth" && disabledDates.contains(selectedDateMillis)) {
+              Toast.makeText(requireContext(), "This date is already used. Please select another.", Toast.LENGTH_SHORT).show()
+              Log.d("DatePicker", "Selected date is disabled")
+              lastValidDate?.let {
+                  val resetCalendar = Calendar.getInstance()
+                  resetCalendar.timeInMillis = it
+                  datePicker.updateDate(
+                      resetCalendar.get(Calendar.YEAR),
+                      resetCalendar.get(Calendar.MONTH),
+                      resetCalendar.get(Calendar.DAY_OF_MONTH)
+                  )
+              }
+          } else {
+              Log.d("DatePicker", "Selected date is valid")
+              lastValidDate = selectedDateMillis
+              viewModel.setHistoricalVisitDate(selectedDate)
+          }
       }
    }
 

--- a/app/src/main/java/com/jnj/vaccinetracker/register/dialogs/HistoricalVisitDateDialog.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/register/dialogs/HistoricalVisitDateDialog.kt
@@ -145,10 +145,25 @@ class HistoricalVisitDateDialog : BaseDialogFragment() {
 
          val visitType = arguments?.getString(VISIT_TYPE) ?: ""
 
-         if (visitType != "At Birth" && disabledDates.contains(selectedDateMillis)) {
+           val selectedDate = DateTime(year, month + 1, day)
+           viewModel.setHistoricalVisitDate(selectedDate)
+           val error = viewModel.errorMessage.value
+
+           if (!error.isNullOrEmpty()) {
+               Toast.makeText(requireContext(), error, Toast.LENGTH_SHORT).show()
+               Log.d("DatePicker", "Selected date is invalid: $error")
+               lastValidDate?.let {
+                   val resetCalendar = Calendar.getInstance()
+                   resetCalendar.timeInMillis = it
+                   datePicker.updateDate(
+                       resetCalendar.get(Calendar.YEAR),
+                       resetCalendar.get(Calendar.MONTH),
+                       resetCalendar.get(Calendar.DAY_OF_MONTH)
+                   )
+               }
+           } else if (visitType != "At Birth" && disabledDates.contains(selectedDateMillis)) {
             Toast.makeText(requireContext(), "This date is already used. Please select another.", Toast.LENGTH_SHORT).show()
             Log.d("DatePicker", "Selected date is disabled")
-
             lastValidDate?.let {
                val resetCalendar = Calendar.getInstance()
                resetCalendar.timeInMillis = it

--- a/app/src/main/java/com/jnj/vaccinetracker/register/dialogs/HistoricalVisitDateDialog.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/register/dialogs/HistoricalVisitDateDialog.kt
@@ -35,7 +35,6 @@ class HistoricalVisitDateDialog : BaseDialogFragment() {
 
    private val viewModel: RegisterParticipantHistoricalDataViewModel by activityViewModels()
 
-
    companion object {
       private const val BIRTH_DATE_STR = "birthDateStr"
       private const val VISIT_TYPE = "visitType"
@@ -57,7 +56,6 @@ class HistoricalVisitDateDialog : BaseDialogFragment() {
    override fun onCreate(savedInstanceState: Bundle?) {
       super.onCreate(savedInstanceState)
       arguments?.getString(BIRTH_DATE_STR)?.let { birthDate = it }
-
       arguments?.getString(DISABLED_DATES_KEY)?.split(",")?.mapNotNull { it.toLongOrNull() }?.let {
          disabledDates.addAll(viewModel.getAllDisabledDates())
       }
@@ -101,7 +99,6 @@ class HistoricalVisitDateDialog : BaseDialogFragment() {
 
          // Always notify listener
          findParent<HistoricalVisitDateListener>()?.onDatePicked(selectedDate)
-
          dismissAllowingStateLoss()
       }
 
@@ -138,11 +135,11 @@ class HistoricalVisitDateDialog : BaseDialogFragment() {
       logDisabledDates()
 
       datePicker.setOnDateChangedListener { _, year, month, day ->
-          val selectedCalendar = Calendar.getInstance()
-          selectedCalendar.set(year, month, day, 0, 0, 0)
-          selectedCalendar.set(Calendar.MILLISECOND, 0)
-          val selectedDateMillis = selectedCalendar.timeInMillis
-          val visitType = arguments?.getString(VISIT_TYPE) ?: ""
+         val selectedCalendar = Calendar.getInstance()
+         selectedCalendar.set(year, month, day, 0, 0, 0)
+         selectedCalendar.set(Calendar.MILLISECOND, 0)
+         val selectedDateMillis = selectedCalendar.timeInMillis
+         val visitType = arguments?.getString(VISIT_TYPE) ?: ""
           val selectedDate = DateTime(year, month + 1, day)
 
           // Chronological order validation
@@ -163,21 +160,21 @@ class HistoricalVisitDateDialog : BaseDialogFragment() {
                   )
               }
           } else if (visitType != "At Birth" && disabledDates.contains(selectedDateMillis)) {
-              Toast.makeText(requireContext(), "This date is already used. Please select another.", Toast.LENGTH_SHORT).show()
-              Log.d("DatePicker", "Selected date is disabled")
-              lastValidDate?.let {
-                  val resetCalendar = Calendar.getInstance()
-                  resetCalendar.timeInMillis = it
-                  datePicker.updateDate(
-                      resetCalendar.get(Calendar.YEAR),
-                      resetCalendar.get(Calendar.MONTH),
-                      resetCalendar.get(Calendar.DAY_OF_MONTH)
-                  )
-              }
-          } else {
-              Log.d("DatePicker", "Selected date is valid")
-              lastValidDate = selectedDateMillis
-              viewModel.setHistoricalVisitDate(selectedDate)
+           Toast.makeText(requireContext(), "This date is already used. Please select another.", Toast.LENGTH_SHORT).show()
+           Log.d("DatePicker", "Selected date is disabled")
+           lastValidDate?.let {
+               val resetCalendar = Calendar.getInstance()
+               resetCalendar.timeInMillis = it
+               datePicker.updateDate(
+                   resetCalendar.get(Calendar.YEAR),
+                   resetCalendar.get(Calendar.MONTH),
+                   resetCalendar.get(Calendar.DAY_OF_MONTH)
+              )
+          }
+         } else {
+            Log.d("DatePicker", "Selected date is valid")
+            lastValidDate = selectedDateMillis
+            viewModel.setHistoricalVisitDate(selectedDate)
           }
       }
    }

--- a/app/src/main/java/com/jnj/vaccinetracker/register/dialogs/PastVisitDateAlertDialog.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/register/dialogs/PastVisitDateAlertDialog.kt
@@ -1,0 +1,49 @@
+package com.jnj.vaccinetracker.register.dialogs
+
+import android.app.Dialog
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.widget.Button
+import android.widget.TextView
+import androidx.fragment.app.DialogFragment
+import com.jnj.vaccinetracker.R
+
+class PastVisitDateAlertDialog(
+    private val title: String,
+    private val message: String,
+    private val buttonLabel: String,
+    private val onButtonClick: (() -> Unit)? = null
+) : DialogFragment() {
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val view = LayoutInflater.from(requireContext())
+            .inflate(R.layout.dialog_past_visit_date_error, null)
+
+        view.findViewById<TextView>(R.id.textView_error_title).text = title
+        view.findViewById<TextView>(R.id.textView_error_description).text = message
+        view.findViewById<Button>(R.id.btn_ok).apply {
+            text = buttonLabel
+            setOnClickListener {
+                onButtonClick?.invoke()
+                dismiss()
+            }
+        }
+
+        val dialog = androidx.appcompat.app.AlertDialog.Builder(requireContext())
+            .setView(view)
+            .create()
+        dialog.setCanceledOnTouchOutside(false)
+        return dialog
+    }
+
+    companion object {
+        fun newInstance(
+            title: String,
+            message: String,
+            buttonLabel: String,
+            onButtonClick: (() -> Unit)? = null
+        ): PastVisitDateAlertDialog {
+            return PastVisitDateAlertDialog(title, message, buttonLabel, onButtonClick)
+        }
+    }
+}

--- a/app/src/main/java/com/jnj/vaccinetracker/register/dialogs/PastVisitDateInfoDialog.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/register/dialogs/PastVisitDateInfoDialog.kt
@@ -1,0 +1,56 @@
+package com.jnj.vaccinetracker.register.dialogs
+
+import android.annotation.SuppressLint
+import android.app.Dialog
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.widget.Button
+import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.DialogFragment
+import com.jnj.vaccinetracker.R
+
+class PastVisitDateInfoDialog(
+    private val onContinue: (() -> Unit)? = null
+) : DialogFragment() {
+
+    @SuppressLint("UseGetLayoutInflater")
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val title = requireArguments().getString(ARG_TITLE)
+        val message = requireArguments().getString(ARG_MESSAGE)
+        val buttonLabel = requireArguments().getString(ARG_BUTTON_LABEL)
+
+        val inflater = LayoutInflater.from(requireContext())
+        val view = inflater.inflate(R.layout.dialog_past_visit_date_info, null)
+
+        view.findViewById<TextView>(R.id.textView_title).text = title
+        view.findViewById<TextView>(R.id.textView_description).text = message
+        view.findViewById<Button>(R.id.btn_continue).apply {
+            text = buttonLabel
+            setOnClickListener {
+                onContinue?.invoke()
+                dismiss()
+            }
+        }
+
+        return AlertDialog.Builder(requireContext())
+            .setView(view)
+            .create()
+    }
+
+    companion object {
+        private const val ARG_TITLE = "title"
+        private const val ARG_MESSAGE = "message"
+        private const val ARG_BUTTON_LABEL = "button_label"
+
+        fun newInstance(title: String, message: String, buttonLabel: String, onContinue: (() -> Unit)?): PastVisitDateInfoDialog {
+            val fragment = PastVisitDateInfoDialog(onContinue)
+            val args = Bundle()
+            args.putString(ARG_TITLE, title)
+            args.putString(ARG_MESSAGE, message)
+            args.putString(ARG_BUTTON_LABEL, buttonLabel)
+            fragment.arguments = args
+            return fragment
+        }
+    }
+}

--- a/app/src/main/java/com/jnj/vaccinetracker/register/dialogs/RegisterParticipantHasChildEverVaccinatedDialog.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/register/dialogs/RegisterParticipantHasChildEverVaccinatedDialog.kt
@@ -23,14 +23,25 @@ class RegisterParticipantHasChildEverVaccinatedDialog : BaseDialogFragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         binding = DataBindingUtil.inflate(inflater, R.layout.dialog_register_participant_has_child_ever_vaccinated, container, false)
         binding.btnYes.setOnClickListener {
-            findParent<RegisterParticipationIsChildNewbornListener>()?.continueRegistrationWithCaptureVaccinesPage()
-            dismissAllowingStateLoss()
+            showFollowDatesInfoDialog()
         }
         binding.btnNo.setOnClickListener {
             findParent<RegisterParticipationIsChildNewbornListener>()?.continueRegistrationWithSuccessDialog()
             dismissAllowingStateLoss()
         }
         return binding.root
+    }
+
+    private fun showFollowDatesInfoDialog() {
+        val infoDialog = PastVisitDateInfoDialog.newInstance(
+            getString(R.string.medical_worker_follow_dates_title),
+            getString(R.string.medical_worker_follow_dates_message),
+            getString(R.string.continue_button_label)
+        ) {
+            findParent<RegisterParticipationIsChildNewbornListener>()?.continueRegistrationWithCaptureVaccinesPage()
+            dismissAllowingStateLoss()
+        }
+        infoDialog.show(parentFragmentManager, "infoDialog")
     }
 
     interface RegisterParticipationIsChildNewbornListener {

--- a/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantHistoricalDataFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantHistoricalDataFragment.kt
@@ -57,27 +57,37 @@ class RegisterParticipantHistoricalDataFragment : BaseFragment(),
    }
 
    override fun onCreateView(
-      inflater: LayoutInflater,
-      container: ViewGroup?,
-      savedInstanceState: Bundle?
+       inflater: LayoutInflater,
+       container: ViewGroup?,
+       savedInstanceState: Bundle?
    ): View {
-      binding = DataBindingUtil.inflate(
-         inflater,
-         R.layout.fragment_register_historical_visits,
-         container,
-         false
-      )
-      binding.apply {
-         viewModel = this@RegisterParticipantHistoricalDataFragment.viewModel
-         lifecycleOwner = viewLifecycleOwner
-         flowViewModel = this@RegisterParticipantHistoricalDataFragment.flowViewModel
-      }
-      viewModel.setArguments(flowViewModel.registerParticipant.value, flowViewModel.participant.value)
-      binding.root.setOnClickListener { activity?.currentFocus?.hideKeyboard() }
+       binding = DataBindingUtil.inflate(
+           inflater,
+           R.layout.fragment_register_historical_visits,
+           container,
+           false
+       )
+       binding.apply {
+           viewModel = this@RegisterParticipantHistoricalDataFragment.viewModel
+           lifecycleOwner = viewLifecycleOwner
+           flowViewModel = this@RegisterParticipantHistoricalDataFragment.flowViewModel
+       }
+       viewModel.setArguments(flowViewModel.registerParticipant.value, flowViewModel.participant.value)
+       binding.root.setOnClickListener { activity?.currentFocus?.hideKeyboard() }
 
-      setupClickListeners()
+       setupClickListeners()
 
-      return binding.root
+       viewModel.errorMessage.observe(viewLifecycleOwner) { message ->
+           if (!message.isNullOrEmpty()) {
+               androidx.appcompat.app.AlertDialog.Builder(requireContext())
+                   .setTitle("Invalid Date")
+                   .setMessage(message)
+                   .setPositiveButton("OK", null)
+                   .show()
+           }
+       }
+
+       return binding.root
    }
 
    override fun observeViewModel(lifecycleOwner: LifecycleOwner) {

--- a/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantHistoricalDataFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantHistoricalDataFragment.kt
@@ -29,11 +29,9 @@ import com.jnj.vaccinetracker.databinding.FragmentRegisterHistoricalVisitsBindin
 import com.jnj.vaccinetracker.participantflow.model.ParticipantSummaryUiModel
 import com.jnj.vaccinetracker.register.RegisterParticipantFlowActivity
 import com.jnj.vaccinetracker.register.RegisterParticipantFlowViewModel
-import com.jnj.vaccinetracker.register.dialogs.HistoricalVisitDateDialog
 import com.jnj.vaccinetracker.register.dialogs.MultipleVisitsDialog
 import com.jnj.vaccinetracker.register.dialogs.PastVisitDateAlertDialog
 import com.jnj.vaccinetracker.register.dialogs.RegisterParticipantSuccessfulDialog
-import com.soywiz.klock.DateTime
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -78,18 +76,18 @@ class RegisterParticipantHistoricalDataFragment : BaseFragment(),
 
        setupClickListeners()
 
-      viewModel.errorMessage.observe(viewLifecycleOwner) { message ->
-     if (!message.isNullOrEmpty()) {
-         val dialog = PastVisitDateAlertDialog.newInstance(
-             title = getString(R.string.past_visit_date_error_title), // Or your custom title
-             message = message,
-             buttonLabel = getString(R.string.past_visit_date_ok) // Or your custom button label
-         ) {
-             viewModel.clearErrorMessage()
+       viewModel.errorMessage.observe(viewLifecycleOwner) { message ->
+           if (!message.isNullOrEmpty()) {
+             val dialog = PastVisitDateAlertDialog.newInstance(
+                 title = getString(R.string.past_visit_date_error_title),
+                 message = message,
+                 buttonLabel = getString(R.string.past_visit_date_ok)
+             ) {
+               viewModel.clearErrorMessage()
+             }
+             dialog.show(parentFragmentManager, "PastVisitDateAlertDialog")
          }
-         dialog.show(parentFragmentManager, "PastVisitDateAlertDialog")
-     }
- }
+       }
 
        return binding.root
    }
@@ -114,19 +112,6 @@ class RegisterParticipantHistoricalDataFragment : BaseFragment(),
                .show(childFragmentManager, TAG_SUCCESS_DIALOG)
          }
          .launchIn(lifecycleOwner.lifecycleScope)
-   }
-
-   private fun showDatePickerDialog() {
-     val birthDate = viewModel.getParticipantBirthDate()
-      val visitType = "historical"
-      val disabledDates = viewModel.getDisabledDatesForVisitType(visitType)
-
-      val dialog = HistoricalVisitDateDialog.create(birthDate, disabledDates, visitType)
-      dialog.show(parentFragmentManager, "HistoricalVisitDateDialog")
-   }
-
-   fun onDatePicked(date: DateTime) {
-      viewModel.setHistoricalVisitDate(date)
    }
 
    private fun setupClickListeners() {

--- a/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantHistoricalDataFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantHistoricalDataFragment.kt
@@ -84,6 +84,7 @@ class RegisterParticipantHistoricalDataFragment : BaseFragment(),
                    .setMessage(message)
                    .setPositiveButton("OK", null)
                    .show()
+               viewModel.clearErrorMessage()
            }
        }
 

--- a/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantHistoricalDataFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantHistoricalDataFragment.kt
@@ -31,6 +31,7 @@ import com.jnj.vaccinetracker.register.RegisterParticipantFlowActivity
 import com.jnj.vaccinetracker.register.RegisterParticipantFlowViewModel
 import com.jnj.vaccinetracker.register.dialogs.HistoricalVisitDateDialog
 import com.jnj.vaccinetracker.register.dialogs.MultipleVisitsDialog
+import com.jnj.vaccinetracker.register.dialogs.PastVisitDateAlertDialog
 import com.jnj.vaccinetracker.register.dialogs.RegisterParticipantSuccessfulDialog
 import com.soywiz.klock.DateTime
 import kotlinx.coroutines.Job
@@ -77,16 +78,18 @@ class RegisterParticipantHistoricalDataFragment : BaseFragment(),
 
        setupClickListeners()
 
-       viewModel.errorMessage.observe(viewLifecycleOwner) { message ->
-           if (!message.isNullOrEmpty()) {
-               androidx.appcompat.app.AlertDialog.Builder(requireContext())
-                   .setTitle("Invalid Date")
-                   .setMessage(message)
-                   .setPositiveButton("OK", null)
-                   .show()
-               viewModel.clearErrorMessage()
-           }
-       }
+      viewModel.errorMessage.observe(viewLifecycleOwner) { message ->
+     if (!message.isNullOrEmpty()) {
+         val dialog = PastVisitDateAlertDialog.newInstance(
+             title = getString(R.string.past_visit_date_error_title), // Or your custom title
+             message = message,
+             buttonLabel = getString(R.string.past_visit_date_ok) // Or your custom button label
+         ) {
+             viewModel.clearErrorMessage()
+         }
+         dialog.show(parentFragmentManager, "PastVisitDateAlertDialog")
+     }
+ }
 
        return binding.root
    }

--- a/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantHistoricalDataViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantHistoricalDataViewModel.kt
@@ -322,7 +322,7 @@ class RegisterParticipantHistoricalDataViewModel @Inject constructor(
 
    }
 
-   private fun isHistoricalVisitDateValid(newVisitDate: DateTime): Boolean {
+   fun isHistoricalVisitDateValid(newVisitDate: DateTime): Boolean {
        val birthDateString = getParticipantBirthDate()
        val birthDate = DateUtil.convertStringToDate(birthDateString, "yyyy-MM-dd")
        val newDateJava = newVisitDate.toDate()
@@ -376,4 +376,7 @@ class RegisterParticipantHistoricalDataViewModel @Inject constructor(
        return true
    }
 
+   fun clearErrorMessage() {
+       errorMessage.value = null
+   }
 }

--- a/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantHistoricalDataViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantHistoricalDataViewModel.kt
@@ -67,10 +67,6 @@ class RegisterParticipantHistoricalDataViewModel @Inject constructor(
       return selectedDate >= birthDate
    }
 
-   fun setAtBirthVisitDate(date: DateTime) {
-      atBirthVisitDate.value = date
-   }
-
    private val disabledDatesByVisitType: MutableMap<String, Set<Long>> = mutableMapOf()
 
    fun getDisabledDatesForVisitType(visitType: String): Set<Long> {
@@ -261,7 +257,6 @@ class RegisterParticipantHistoricalDataViewModel @Inject constructor(
    ) {
       if (visitDate != null) {
          if (!isHistoricalVisitDateValid(visitDate)) return
-         if (!isVisitDateNotBeforePrevious(visitDate)) return
       }
 
       val currentData = visitTypesData.value ?: mutableMapOf()
@@ -335,20 +330,6 @@ class RegisterParticipantHistoricalDataViewModel @Inject constructor(
            return false
        }
 
-       return true
-   }
-
-   private fun isVisitDateNotBeforePrevious(newVisitDate: DateTime): Boolean {
-       val previousVisitDates = visitTypesData.value?.values
-           ?.mapNotNull { it.visitDate }
-           ?.map { it.time }
-           ?: emptyList()
-       val newDateMillis = newVisitDate.toDate().time
-
-       if (previousVisitDates.any { newDateMillis < it }) {
-           errorMessage.postValue("Visit date cannot be before a previously entered visit.")
-           return false
-       }
        return true
    }
 

--- a/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantHistoricalDataViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantHistoricalDataViewModel.kt
@@ -340,21 +340,21 @@ class RegisterParticipantHistoricalDataViewModel @Inject constructor(
            return false
        }
 
-       // Not overlapping with other visits
-       val allVisits = groupedVisitsByType.value?.values?.flatten() ?: emptyList()
+       // Collect all visit dates: registered + current session
+       val allVisits = (groupedVisitsByType.value?.values?.flatten() ?: emptyList())
+       val sessionDates = visitTypesData.value?.values?.mapNotNull { it.visitDate } ?: emptyList()
+       val allVisitDates = allVisits.map { it.visitDate.time } + sessionDates.map { it.time }
+
        val newDateMidnight = newDateJava.time.toMidnight()
-       val overlap = allVisits.any { visit ->
-           visit.visitDate.time.toMidnight() == newDateMidnight
-       }
+       val overlap = allVisitDates.any { it.toMidnight() == newDateMidnight }
        if (overlap) {
            errorMessage.postValue("Visit date overlaps with an existing visit.")
            return false
        }
 
        // Chronological order: must be after all previous visits
-       val previousVisitDates = allVisits.map { it.visitDate.time }
-       if (previousVisitDates.any { newDateJava.time <= it }) {
-           errorMessage.postValue("Visit date must be after all previous visits.")
+       if (allVisitDates.any { newDateJava.time <= it }) {
+           errorMessage.postValue("The selected date is before or the same as a previous visit. Please select a later date.")
            return false
        }
 
@@ -364,10 +364,10 @@ class RegisterParticipantHistoricalDataViewModel @Inject constructor(
    private fun isVisitDateNotBeforePrevious(newVisitDate: DateTime): Boolean {
        val previousVisitDates = visitTypesData.value?.values
            ?.mapNotNull { it.visitDate }
-           ?.map { it.time } // it is Date, so use .time
+           ?.map { it.time }
            ?: emptyList()
        val newDateMillis = newVisitDate.toDate().time
-   
+
        // Ensure new visit date is not before any previous visit
        if (previousVisitDates.any { newDateMillis < it }) {
            errorMessage.postValue("Visit date cannot be before a previously entered visit.")

--- a/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantHistoricalDataViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantHistoricalDataViewModel.kt
@@ -277,6 +277,11 @@ class RegisterParticipantHistoricalDataViewModel @Inject constructor(
       otherSubstancesAndValues: MutableMap<String, String>,
       visitDate: DateTime?
    ) {
+      if (visitDate != null) {
+         if (!isHistoricalVisitDateValid(visitDate)) return
+         if (!isVisitDateNotBeforePrevious(visitDate)) return
+      }
+
       val currentData = visitTypesData.value ?: mutableMapOf()
       val visitTypeEntry = currentData.getOrPut(visitTypeName) { HistoricalData(null, emptyMap()) }
       val substances = SubstancesData(substancesAndDates?.toMap() ?: emptyMap())
@@ -289,8 +294,6 @@ class RegisterParticipantHistoricalDataViewModel @Inject constructor(
          )
       )
       currentData[visitTypeName] = updatedVisitTypeEntry
-
-
       visitTypesData.postValue(currentData)
    }
 
@@ -318,4 +321,60 @@ class RegisterParticipantHistoricalDataViewModel @Inject constructor(
         Log.d("HistoricalVisit", "Set historical visit date: $date")
 
    }
+
+   // Kotlin
+    fun isHistoricalVisitDateValid(newVisitDate: DateTime): Boolean {
+       val birthDateString = getParticipantBirthDate()
+       val birthDate = DateUtil.convertStringToDate(birthDateString, "yyyy-MM-dd")
+       val newDateJava = newVisitDate.toDate()
+       val today = Date()
+
+       // Not before birth date
+       if (birthDate != null && newDateJava.before(birthDate)) {
+           errorMessage.postValue("Visit date cannot be before birth date.")
+           return false
+       }
+
+       // Not in the future
+       if (newDateJava.after(today)) {
+           errorMessage.postValue("Visit date cannot be in the future.")
+           return false
+       }
+
+       // Not overlapping with other visits
+       val allVisits = groupedVisitsByType.value?.values?.flatten() ?: emptyList()
+       val newDateMidnight = newDateJava.time.toMidnight()
+       val overlap = allVisits.any { visit ->
+           visit.visitDate.time.toMidnight() == newDateMidnight
+       }
+       if (overlap) {
+           errorMessage.postValue("Visit date overlaps with an existing visit.")
+           return false
+       }
+
+       // Chronological order: must be after all previous visits
+       val previousVisitDates = allVisits.map { it.visitDate.time }
+       if (previousVisitDates.any { newDateJava.time <= it }) {
+           errorMessage.postValue("Visit date must be after all previous visits.")
+           return false
+       }
+
+       return true
+   }
+
+   fun isVisitDateNotBeforePrevious(newVisitDate: DateTime): Boolean {
+       val previousVisitDates = visitTypesData.value?.values
+           ?.mapNotNull { it.visitDate }
+           ?.map { it.time } // it is Date, so use .time
+           ?: emptyList()
+       val newDateMillis = newVisitDate.toDate().time
+   
+       // Ensure new visit date is not before any previous visit
+       if (previousVisitDates.any { newDateMillis < it }) {
+           errorMessage.postValue("Visit date cannot be before a previously entered visit.")
+           return false
+       }
+       return true
+   }
+
 }

--- a/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantHistoricalDataViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantHistoricalDataViewModel.kt
@@ -322,8 +322,7 @@ class RegisterParticipantHistoricalDataViewModel @Inject constructor(
 
    }
 
-   // Kotlin
-    fun isHistoricalVisitDateValid(newVisitDate: DateTime): Boolean {
+   private fun isHistoricalVisitDateValid(newVisitDate: DateTime): Boolean {
        val birthDateString = getParticipantBirthDate()
        val birthDate = DateUtil.convertStringToDate(birthDateString, "yyyy-MM-dd")
        val newDateJava = newVisitDate.toDate()
@@ -362,7 +361,7 @@ class RegisterParticipantHistoricalDataViewModel @Inject constructor(
        return true
    }
 
-   fun isVisitDateNotBeforePrevious(newVisitDate: DateTime): Boolean {
+   private fun isVisitDateNotBeforePrevious(newVisitDate: DateTime): Boolean {
        val previousVisitDates = visitTypesData.value?.values
            ?.mapNotNull { it.visitDate }
            ?.map { it.time } // it is Date, so use .time

--- a/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantHistoricalDataViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantHistoricalDataViewModel.kt
@@ -3,7 +3,6 @@ package com.jnj.vaccinetracker.register.screens
 import android.os.Build
 import android.util.Log
 import androidx.annotation.RequiresApi
-import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.jnj.vaccinetracker.common.data.managers.VisitManager
 import com.jnj.vaccinetracker.common.data.models.Constants
@@ -33,7 +32,6 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.yield
-import java.time.LocalDate
 import java.util.Date
 import javax.inject.Inject
 
@@ -59,16 +57,8 @@ class RegisterParticipantHistoricalDataViewModel @Inject constructor(
    val groupedVisitsByType = mutableLiveData<Map<String, List<VisitDetail>>>()
    val visitTypesData = mutableLiveData<MutableMap<String, HistoricalData>>(mutableMapOf())
    private val _historicalVisitDates = MutableLiveData<List<DateTime>>(emptyList())
-   val historicalVisitDates: LiveData<List<DateTime>> get() = _historicalVisitDates
-   private val _disabledDates = MutableLiveData<MutableSet<Long>>().apply {
-      value = mutableSetOf()
-   }
-   private val disabledDates: LiveData<MutableSet<Long>> = _disabledDates
    private val allDisabledDates = mutableSetOf<Long>()
    fun getAllDisabledDates(): Set<Long> = allDisabledDates
-   private val _actionLiveData = MutableLiveData<String>()
-   val actionLiveData: LiveData<String> = _actionLiveData
-
    private val atBirthVisitDate = mutableLiveData<DateTime?>()
 
    fun isDateValidForVisitType(visitType: String, selectedDate: DateTime): Boolean {
@@ -91,7 +81,6 @@ class RegisterParticipantHistoricalDataViewModel @Inject constructor(
       }
    }
 
-
    fun setDisabledDatesForVisitType(visitType: String, dates: Set<Long>) {
       if (visitType != "At Birth") {
          disabledDatesByVisitType[visitType] = dates
@@ -101,12 +90,6 @@ class RegisterParticipantHistoricalDataViewModel @Inject constructor(
    fun addDisabledDate(date: Long) {
       allDisabledDates.add(date)
    }
-
-   fun setAllDisabledDates(dates: Set<Long>) {
-      allDisabledDates.clear()
-      allDisabledDates.addAll(dates)
-   }
-
 
    init {
       participantSummaryArg
@@ -161,7 +144,6 @@ class RegisterParticipantHistoricalDataViewModel @Inject constructor(
       cal.set(java.util.Calendar.MILLISECOND, 0)
       return cal.timeInMillis
    }
-
 
    private fun buildHistoricalVisitObject(
       participant: ParticipantSummaryUiModel,
@@ -319,7 +301,6 @@ class RegisterParticipantHistoricalDataViewModel @Inject constructor(
    fun setHistoricalVisitDate(date: DateTime) {
         _historicalVisitDates.value = _historicalVisitDates.value?.plus(date) ?: listOf(date)
         Log.d("HistoricalVisit", "Set historical visit date: $date")
-
    }
 
    fun isHistoricalVisitDateValid(newVisitDate: DateTime): Boolean {
@@ -328,19 +309,16 @@ class RegisterParticipantHistoricalDataViewModel @Inject constructor(
        val newDateJava = newVisitDate.toDate()
        val today = Date()
 
-       // Not before birth date
        if (birthDate != null && newDateJava.before(birthDate)) {
            errorMessage.postValue("Visit date cannot be before birth date.")
            return false
        }
 
-       // Not in the future
        if (newDateJava.after(today)) {
            errorMessage.postValue("Visit date cannot be in the future.")
            return false
        }
 
-       // Collect all visit dates: registered + current session
        val allVisits = (groupedVisitsByType.value?.values?.flatten() ?: emptyList())
        val sessionDates = visitTypesData.value?.values?.mapNotNull { it.visitDate } ?: emptyList()
        val allVisitDates = allVisits.map { it.visitDate.time } + sessionDates.map { it.time }
@@ -352,7 +330,6 @@ class RegisterParticipantHistoricalDataViewModel @Inject constructor(
            return false
        }
 
-       // Chronological order: must be after all previous visits
        if (allVisitDates.any { newDateJava.time <= it }) {
            errorMessage.postValue("The selected date is before or the same as a previous visit. Please select a later date.")
            return false
@@ -368,7 +345,6 @@ class RegisterParticipantHistoricalDataViewModel @Inject constructor(
            ?: emptyList()
        val newDateMillis = newVisitDate.toDate().time
 
-       // Ensure new visit date is not before any previous visit
        if (previousVisitDates.any { newDateMillis < it }) {
            errorMessage.postValue("Visit date cannot be before a previously entered visit.")
            return false

--- a/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantHistoricalDataViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantHistoricalDataViewModel.kt
@@ -330,8 +330,8 @@ class RegisterParticipantHistoricalDataViewModel @Inject constructor(
            return false
        }
 
-       if (allVisitDates.any { newDateJava.time <= it }) {
-           errorMessage.postValue("The selected date is before or the same as a previous visit. Please select a later date.")
+       if (allVisitDates.any { newDateJava.time < it }) {
+           errorMessage.postValue("The selected date is before a previous visit. Please select a later date.")
            return false
        }
 

--- a/app/src/main/res/layout/dialog_past_visit_date_error.xml
+++ b/app/src/main/res/layout/dialog_past_visit_date_error.xml
@@ -23,7 +23,7 @@
                 android:layout_marginBottom="30dp"
                 android:gravity="center"
                 android:scaleType="fitCenter"
-                android:src="@drawable/ic_checkmark_alert"
+                android:src="@drawable/ic_x_circle"
                 app:tint="@color/colorTextOnPrimary" />
         </FrameLayout>
 

--- a/app/src/main/res/layout/dialog_past_visit_date_error.xml
+++ b/app/src/main/res/layout/dialog_past_visit_date_error.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <FrameLayout
+            android:id="@+id/frameLayout"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:background="@color/alertLight"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageView
+                android:id="@+id/imageView_error"
+                android:layout_width="match_parent"
+                android:layout_height="120dp"
+                android:layout_marginTop="30dp"
+                android:layout_marginBottom="30dp"
+                android:gravity="center"
+                android:scaleType="fitCenter"
+                android:src="@drawable/ic_checkmark_alert"
+                app:tint="@color/colorTextOnPrimary" />
+        </FrameLayout>
+
+        <TextView
+            android:id="@+id/textView_error_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginEnd="16dp"
+            android:gravity="center_horizontal"
+            android:text="@string/past_visit_date_error_title"
+            android:textAppearance="@style/PopupTitle"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/frameLayout" />
+
+        <TextView
+            android:id="@+id/textView_error_description"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginEnd="16dp"
+            android:text="@string/past_visit_date_error_message"
+            android:textAlignment="center"
+            android:textAppearance="@style/GeneralText"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/textView_error_title" />
+
+        <Button
+            android:id="@+id/btn_ok"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            android:layout_marginBottom="16dp"
+            android:backgroundTint="@color/colorPrimary"
+            android:textAppearance="@style/ButtonTextStyling"
+            android:text="@string/past_visit_date_ok"
+            android:textColor="@color/colorTextOnSecondary"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/textView_error_description" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/app/src/main/res/layout/dialog_past_visit_date_info.xml
+++ b/app/src/main/res/layout/dialog_past_visit_date_info.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <FrameLayout
+            android:id="@+id/frameLayout"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:background="@color/alertLight"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageView
+                android:id="@+id/imageView_info"
+                android:layout_width="match_parent"
+                android:layout_height="120dp"
+                android:layout_marginTop="30dp"
+                android:layout_marginBottom="30dp"
+                android:gravity="center"
+                android:scaleType="fitCenter"
+                android:src="@drawable/ic_checkmark_alert"
+                app:tint="@color/colorTextOnPrimary" />
+        </FrameLayout>
+
+        <TextView
+            android:id="@+id/textView_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginEnd="16dp"
+            android:gravity="center_horizontal"
+            android:text="@string/medical_worker_follow_dates_title"
+            android:textAppearance="@style/PopupTitle"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/frameLayout" />
+
+        <TextView
+            android:id="@+id/textView_description"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginEnd="16dp"
+            android:text="@string/medical_worker_follow_dates_message"
+            android:textAlignment="center"
+            android:textAppearance="@style/GeneralText"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/textView_title" />
+
+        <Button
+            android:id="@+id/btn_continue"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            android:layout_marginBottom="16dp"
+            android:backgroundTint="@color/colorPrimary"
+            android:textAppearance="@style/ButtonTextStyling"
+            android:text="@string/continue_button_label"
+            android:textColor="@color/colorTextOnSecondary"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/textView_description" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -232,7 +232,7 @@
     <string name="visit_schedule_visit_failed">Saving visit failed</string>
     <string name="continue_button_label">Continue</string>
     <string name="medical_worker_follow_dates_title">Past Visit Dates</string>
-    <string name="medical_worker_follow_dates_message">Please follow the dates on child card as you enter the past visits.</string>
+    <string name="medical_worker_follow_dates_message">Please follow the dates on child card while entering the past visits details.</string>
     <string name="visit_dosing_warning_out_of_time_window_description">Please confirm that this child is receiving a dosage before the scheduled date.</string>
     <string name="visit_dosing_warning_far_from_time_window_description">Please note that this child is not due for the next visit.</string>
     <string name="visit_dosing_warning_out_of_time_window_title">Dosing outside of window</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -230,6 +230,9 @@
     <string name="visit_schedule_next_visit_save_visit_button_label">Save Visit</string>
     <string name="visit_schedule_visit_saved_successfully_label">Next visit successfully registered on: </string>
     <string name="visit_schedule_visit_failed">Saving visit failed</string>
+    <string name="continue_button_label">Continue</string>
+    <string name="medical_worker_follow_dates_title">Past Visit Dates</string>
+    <string name="medical_worker_follow_dates_message">Please follow the dates on child card as you enter the past visits.</string>
     <string name="visit_dosing_warning_out_of_time_window_description">Please confirm that this child is receiving a dosage before the scheduled date.</string>
     <string name="visit_dosing_warning_far_from_time_window_description">Please note that this child is not due for the next visit.</string>
     <string name="visit_dosing_warning_out_of_time_window_title">Dosing outside of window</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -232,7 +232,7 @@
     <string name="visit_schedule_visit_failed">Saving visit failed</string>
     <string name="continue_button_label">Continue</string>
     <string name="medical_worker_follow_dates_title">Past Visit Dates</string>
-    <string name="medical_worker_follow_dates_message">Please follow the dates on child card while entering the past visits details.</string>
+    <string name="medical_worker_follow_dates_message">Please follow the visit dates on child card while entering the past visits details.</string>
     <string name="visit_dosing_warning_out_of_time_window_description">Please confirm that this child is receiving a dosage before the scheduled date.</string>
     <string name="visit_dosing_warning_far_from_time_window_description">Please note that this child is not due for the next visit.</string>
     <string name="visit_dosing_warning_out_of_time_window_title">Dosing outside of window</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -230,6 +230,9 @@
     <string name="visit_schedule_next_visit_save_visit_button_label">Save Visit</string>
     <string name="visit_schedule_visit_saved_successfully_label">Next visit successfully registered on: </string>
     <string name="visit_schedule_visit_failed">Saving visit failed</string>
+    <string name="past_visit_date_ok">Okay</string>
+    <string name="past_visit_date_error_title">Visit Not Saved Due To Invalid Date</string>
+    <string name="past_visit_date_error_message">The selected date is before or the same as a previous visit. Please select a later date. Please follow the dates on the child card.</string>
     <string name="continue_button_label">Continue</string>
     <string name="medical_worker_follow_dates_title">Past Visit Dates</string>
     <string name="medical_worker_follow_dates_message">Please follow the visit dates on child card while entering the past visits details.</string>


### PR DESCRIPTION
# This PR focuses on

1. A pop up to remind health workers to follow dates on the child card
2. A pop up showing that the visit was not saved when invalid date is picked
3. A toast on the calendar to inform a user that the date picked is already used or the date is before the previous visit
4. To arrange the past visit in Chronological order