### PR TITLE
Feature enable to edit gender field

### DIFF
--- a/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantParticipantDetailsFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantParticipantDetailsFragment.kt
@@ -201,8 +201,6 @@ class RegisterParticipantParticipantDetailsFragment : BaseFragment(),
 
     private fun setupEditableFields() {
         if (viewModel.participantUuid.value != null) {
-            binding.rbGenderMale.isEnabled = false
-            binding.rbGenderFemale.isEnabled = false
             if (flowViewModel.duplicateError.value != ParticipantAlreadyExistsException.toStringExceptionName()) {
                 binding.btnScanParticipantId.visibility = View.INVISIBLE
             }


### PR DESCRIPTION
# This PR focuses on;

This PR enables editing of the gender field during participant detail updates by removing the code that previously disabled gender radio buttons when a participant UUID exists.

1. Removes the disabled state for gender radio buttons (male/female) in edit mode
2. Allows users to modify gender information when updating existing participant details