### PR TITLE
Display outreach name on home page

### DIFF
--- a/app/src/main/java/com/jnj/vaccinetracker/participantflow/ParticipantFlowActivity.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/participantflow/ParticipantFlowActivity.kt
@@ -46,10 +46,9 @@ class ParticipantFlowActivity : BaseActivity() {
         binding.lifecycleOwner = this
 
         val sharedPreferences = getSharedPreferences(Constants.USER_PREFERENCES_FILE_NAME, Context.MODE_PRIVATE)
-        val outreachName = sharedPreferences.getString(Constants.OUTREACH_NAME, "")
-        val visitPlace = sharedPreferences.getString(Constants.VISIT_PLACE_FILE_KEY, "")
-
-        viewModel.setOutreachName(visitPlace ?: "", outreachName)
+        val outreachName = sharedPreferences.getString(Constants.OUTREACH_NAME, "") ?: ""
+        val visitPlace = sharedPreferences.getString(Constants.VISIT_PLACE_FILE_KEY, "") ?: ""
+        viewModel.setOutreachName(visitPlace, outreachName)
 
         viewModel.currentScreen.observe(this) { screen ->
             navigateToScreen(screen, viewModel.navigationDirection)

--- a/app/src/main/java/com/jnj/vaccinetracker/participantflow/ParticipantFlowActivity.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/participantflow/ParticipantFlowActivity.kt
@@ -45,6 +45,12 @@ class ParticipantFlowActivity : BaseActivity() {
         binding.viewModel = viewModel
         binding.lifecycleOwner = this
 
+        val sharedPreferences = getSharedPreferences(Constants.USER_PREFERENCES_FILE_NAME, Context.MODE_PRIVATE)
+        val outreachName = sharedPreferences.getString(Constants.OUTREACH_NAME, "")
+        val visitPlace = sharedPreferences.getString(Constants.VISIT_PLACE_FILE_KEY, "")
+
+        viewModel.setOutreachName(visitPlace ?: "", outreachName)
+
         viewModel.currentScreen.observe(this) { screen ->
             navigateToScreen(screen, viewModel.navigationDirection)
         }

--- a/app/src/main/java/com/jnj/vaccinetracker/participantflow/ParticipantFlowViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/participantflow/ParticipantFlowViewModel.kt
@@ -63,7 +63,7 @@ class ParticipantFlowViewModel @Inject constructor(
     val site = mutableLiveData<SiteUiModel>()
     val operator = mutableLiveData<String>()
     val errorMessage = mutableLiveData<String>()
-    val outreachName = mutableLiveData<String>("") // or get from SharedPreferences
+    val outreachName = mutableLiveData<String>("")
 
     //id variables
     val participantId = mutableLiveData<String>()

--- a/app/src/main/java/com/jnj/vaccinetracker/participantflow/ParticipantFlowViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/participantflow/ParticipantFlowViewModel.kt
@@ -63,6 +63,7 @@ class ParticipantFlowViewModel @Inject constructor(
     val site = mutableLiveData<SiteUiModel>()
     val operator = mutableLiveData<String>()
     val errorMessage = mutableLiveData<String>()
+    val outreachName = mutableLiveData<String>("") // or get from SharedPreferences
 
     //id variables
     val participantId = mutableLiveData<String>()
@@ -398,6 +399,14 @@ class ParticipantFlowViewModel @Inject constructor(
         irisIndexes.clear()
         irisScans.clear()
         tempTemplateFile.delete()
+    }
+
+    fun setOutreachName(visitPlace: String, outreachName: String?) {
+        if (visitPlace == Constants.VISIT_PLACE_OUTREACH && !outreachName.isNullOrBlank()) {
+            this.outreachName.value = outreachName
+        } else {
+            this.outreachName.value = ""
+        }
     }
 
     enum class WorkflowItem(val type: String, var mandatory: Boolean) {

--- a/app/src/main/java/com/jnj/vaccinetracker/participantflow/ParticipantFlowViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/participantflow/ParticipantFlowViewModel.kt
@@ -5,6 +5,7 @@ import android.os.Parcel
 import android.os.Parcelable
 import androidx.annotation.StringRes
 import androidx.collection.ArrayMap
+import androidx.lifecycle.MutableLiveData
 import com.jnj.vaccinetracker.R
 import com.jnj.vaccinetracker.common.data.helpers.AndroidFiles
 import com.jnj.vaccinetracker.common.data.managers.ConfigurationManager
@@ -63,7 +64,7 @@ class ParticipantFlowViewModel @Inject constructor(
     val site = mutableLiveData<SiteUiModel>()
     val operator = mutableLiveData<String>()
     val errorMessage = mutableLiveData<String>()
-    val outreachName = mutableLiveData<String>("")
+    val outreachName = MutableLiveData<String>("")
 
     //id variables
     val participantId = mutableLiveData<String>()

--- a/app/src/main/res/layout/fragment_participant_add_or_search.xml
+++ b/app/src/main/res/layout/fragment_participant_add_or_search.xml
@@ -23,13 +23,13 @@
             android:layout_height="@dimen/welcome_height"
             android:layout_marginHorizontal="@dimen/margin_16_32"
             android:layout_marginVertical="@dimen/margin_16_32"
-            android:text="@{@string/match_or_register_patient_welcome(viewModel.operator, viewModel.site.displayName)}"
+            android:text='@{String.format(@string/match_or_register_patient_welcome, viewModel.operator, viewModel.site.displayName, viewModel.outreachName != null &amp;&amp; !viewModel.outreachName.isEmpty() ? " (Outreah: " + viewModel.outreachName + ")" : "")}'
             android:textAppearance="@style/ScreenTitle"
             android:textAlignment="center"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            tools:text="@string/match_or_register_patient_welcome" />
+            tools:text="Welcome Operator to Site (OutreachName)" />
 
 
         <LinearLayout

--- a/app/src/main/res/layout/fragment_participant_add_or_search.xml
+++ b/app/src/main/res/layout/fragment_participant_add_or_search.xml
@@ -23,13 +23,13 @@
             android:layout_height="@dimen/welcome_height"
             android:layout_marginHorizontal="@dimen/margin_16_32"
             android:layout_marginVertical="@dimen/margin_16_32"
-            android:text='@{String.format(@string/match_or_register_patient_welcome, viewModel.operator, viewModel.site.displayName, viewModel.outreachName != null &amp;&amp; !viewModel.outreachName.isEmpty() ? " (Outreah: " + viewModel.outreachName + ")" : "")}'
+            android:text='@{String.format(@string/match_or_register_patient_welcome, viewModel.operator, viewModel.site.displayName, viewModel.outreachName != null &amp;&amp; !viewModel.outreachName.isEmpty() ? " (Outreach: " + viewModel.outreachName + ")" : "")}'
             android:textAppearance="@style/ScreenTitle"
             android:textAlignment="center"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            tools:text="Welcome Operator to Site (OutreachName)" />
+            tools:text="Welcome Operator to Site (Outreach: Outreach Name)" />
 
 
         <LinearLayout

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,7 +74,7 @@
     <string name="site_selection_input_hint">Select site location</string>
     <string name="site_selection_btn_submit">Submit</string>
     <string name="site_selection_error_no_site_selected">Please select a site</string>
-    <string name="match_or_register_patient_welcome">Welcome operator %s, you are currently at site %s</string>
+    <string name="match_or_register_patient_welcome">Welcome %1$s to %2$s%3$s</string>
     <string name="match_or_register_patient_step_id_card">Child ID or QR-Code</string>
     <string name="match_or_register_patient_step_phone">Phone number</string>
     <string name="match_or_register_patient_step_iris_scan">Iris scan the Child\'s eye(s)</string>


### PR DESCRIPTION
# This PR focuses on;

This PR implements the display of outreach names on the home page by retrieving the outreach name from shared preferences and conditionally showing it in the welcome message UI.

Updates the welcome message string format to accommodate three parameters instead of two
Modifies the UI layout to conditionally display outreach name when present
Adds outreach name handling in the ViewModel and Activity classes