### PR TITLE
Update/save btn flow after child update

### DIFF
--- a/app/src/main/java/com/jnj/vaccinetracker/register/dialogs/UpdateParticipantSuccessfulDialog.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/register/dialogs/UpdateParticipantSuccessfulDialog.kt
@@ -25,8 +25,8 @@ class UpdateParticipantSuccessfulDialog : BaseDialogFragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         binding = DataBindingUtil.inflate(inflater, R.layout.dialog_update_participant_successful, container, false)
         binding.btnOk.setOnClickListener {
-            requireActivity().onBackPressedDispatcher.onBackPressed()
             dismissAllowingStateLoss()
+            requireActivity().onBackPressedDispatcher.onBackPressed()
         }
         return binding.root
     }

--- a/app/src/main/java/com/jnj/vaccinetracker/register/dialogs/UpdateParticipantSuccessfulDialog.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/register/dialogs/UpdateParticipantSuccessfulDialog.kt
@@ -13,10 +13,7 @@ import com.jnj.vaccinetracker.databinding.DialogUpdateParticipantSuccessfulBindi
  * @author maartenvangiel
  * @version 1
  */
-class UpdateParticipantSuccessfulDialog(
-    private val listener: OnParticipantUpdateConfirmedListener
-) : BaseDialogFragment() {
-
+class UpdateParticipantSuccessfulDialog : BaseDialogFragment() {
     private lateinit var binding: DialogUpdateParticipantSuccessfulBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -28,13 +25,9 @@ class UpdateParticipantSuccessfulDialog(
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         binding = DataBindingUtil.inflate(inflater, R.layout.dialog_update_participant_successful, container, false)
         binding.btnOk.setOnClickListener {
-            dismiss()
-            listener.onParticipantUpdateConfirmed()
+            requireActivity().onBackPressedDispatcher.onBackPressed()
+            dismissAllowingStateLoss()
         }
         return binding.root
-    }
-
-    interface OnParticipantUpdateConfirmedListener {
-        fun onParticipantUpdateConfirmed()
     }
 }

--- a/app/src/main/java/com/jnj/vaccinetracker/register/screens/HistoricalDataForVisitTypeFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/register/screens/HistoricalDataForVisitTypeFragment.kt
@@ -45,7 +45,6 @@ import com.jnj.vaccinetracker.register.dialogs.VaccineDialog
 import com.jnj.vaccinetracker.sync.data.repositories.SyncSettingsRepository
 import com.jnj.vaccinetracker.visit.model.OtherSubstanceDataModel
 import com.jnj.vaccinetracker.visit.model.SubstanceDataModel
-import com.jnj.vaccinetracker.visitsoverview.screens.VisitsOverviewFragment
 import com.soywiz.klock.DateFormat
 import com.soywiz.klock.DateTime
 import com.soywiz.klock.jvm.toDate
@@ -475,14 +474,7 @@ class HistoricalDataForVisitTypeFragment :
    }
 
    private fun showSuccessDialog() {
-      UpdateParticipantSuccessfulDialog(object : UpdateParticipantSuccessfulDialog.OnParticipantUpdateConfirmedListener {
-         override fun onParticipantUpdateConfirmed() {
-            parentFragmentManager.beginTransaction()
-               .replace(R.id.fragment_container, VisitsOverviewFragment())
-               .addToBackStack(null)
-               .commit()
-         }
-      }).show(
+      UpdateParticipantSuccessfulDialog().show(
          childFragmentManager,
          RegisterParticipantParticipantDetailsFragment.TAG_UPDATE_SUCCESS_DIALOG
       )

--- a/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantParticipantDetailsFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantParticipantDetailsFragment.kt
@@ -39,11 +39,9 @@ import com.jnj.vaccinetracker.participantflow.model.ParticipantSummaryUiModel
 import com.jnj.vaccinetracker.register.RegisterParticipantFlowActivity
 import com.jnj.vaccinetracker.register.RegisterParticipantFlowViewModel
 import com.jnj.vaccinetracker.register.dialogs.*
-import com.jnj.vaccinetracker.visitsoverview.screens.VisitsOverviewFragment
 import com.soywiz.klock.DateFormat
 import com.soywiz.klock.DateTime
 import kotlinx.coroutines.flow.onEach
-import java.util.Locale
 
 /**
  * @author maartenvangiel
@@ -186,16 +184,9 @@ class RegisterParticipantParticipantDetailsFragment : BaseFragment(),
             }.launchIn(lifecycleOwner)
         updateParticipantSuccessDialogEvents
             .asFlow()
-            .onEach {
+            .onEach { participant ->
                 setupEditableFields()
-                UpdateParticipantSuccessfulDialog(object : UpdateParticipantSuccessfulDialog.OnParticipantUpdateConfirmedListener {
-                    override fun onParticipantUpdateConfirmed() {
-                        parentFragmentManager.beginTransaction()
-                            .replace(R.id.fragment_container, VisitsOverviewFragment())
-                            .addToBackStack(null)
-                            .commit()
-                    }
-                }).show(childFragmentManager, TAG_UPDATE_SUCCESS_DIALOG)
+                UpdateParticipantSuccessfulDialog().show(childFragmentManager, TAG_UPDATE_SUCCESS_DIALOG)
             }.launchIn(lifecycleOwner)
     }
 

--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/activity/VisitsOverviewFlowActivity.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/activity/VisitsOverviewFlowActivity.kt
@@ -72,5 +72,6 @@ class VisitsOverviewFlowActivity : BaseActivity() {
         intent.putExtra(Constants.CALL_NAVIGATE_TO_MATCH_SCREEN, true)
         intent.putExtra(Constants.PARTICIPANT_MATCH_ID, childID)
         startActivity(intent)
+        finish()
     }
 }

--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/dialog/VisitDetailsDialog.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/dialog/VisitDetailsDialog.kt
@@ -39,8 +39,10 @@ class VisitDetailsDialog : BaseDialogFragment() {
         binding.closeButton.setOnClickListener { dismissAllowingStateLoss() }
         binding.childDetailsButton.setOnClickListener {
             val childId = visitDetails.clientID
-            (activity as? VisitsOverviewFlowActivity)?. goToRegisteredParticipant(childId)
-            dismissAllowingStateLoss()
+            if (!childId.isNullOrBlank()) {
+                (activity as? VisitsOverviewFlowActivity)?.goToRegisteredParticipant(childId)
+                dismissAllowingStateLoss()
+            }
         }
         return binding.root
     }

--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/dialog/VisitDetailsDialog.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/dialog/VisitDetailsDialog.kt
@@ -1,6 +1,5 @@
 package com.jnj.vaccinetracker.visitsoverview.dialog
 
-import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -11,10 +10,9 @@ import androidx.core.content.ContextCompat
 import androidx.databinding.DataBindingUtil
 import com.jnj.vaccinetracker.R
 import com.jnj.vaccinetracker.common.data.models.Constants
-import com.jnj.vaccinetracker.common.helpers.logInfo
 import com.jnj.vaccinetracker.common.ui.BaseDialogFragment
 import com.jnj.vaccinetracker.databinding.DialogVisitDetailsBinding
-import com.jnj.vaccinetracker.participantflow.ParticipantFlowActivity
+import com.jnj.vaccinetracker.visitsoverview.activity.VisitsOverviewFlowActivity
 import com.jnj.vaccinetracker.visitsoverview.dto.VisitDetailsDTO
 
 class VisitDetailsDialog : BaseDialogFragment() {
@@ -41,17 +39,7 @@ class VisitDetailsDialog : BaseDialogFragment() {
         binding.closeButton.setOnClickListener { dismissAllowingStateLoss() }
         binding.childDetailsButton.setOnClickListener {
             val childId = visitDetails.clientID
-            if (childId.isEmpty()) {
-                logInfo("Child ID is null or empty, cannot navigate to child matching page.")
-                return@setOnClickListener
-            }
-            activity?.let { currentActivity ->
-                val intent = Intent(currentActivity, ParticipantFlowActivity::class.java).apply {
-                    putExtra(Constants.CALL_NAVIGATE_TO_MATCH_SCREEN, true)
-                    putExtra(Constants.PARTICIPANT_MATCH_ID, childId)
-                }
-                currentActivity.startActivity(intent)
-            } ?: logInfo("Activity reference is null.")
+            (activity as? VisitsOverviewFlowActivity)?. goToRegisteredParticipant(childId)
             dismissAllowingStateLoss()
         }
         return binding.root


### PR DESCRIPTION
# This PR focuses on;

1.  To simplify the participant update flow by removing the custom listener and navigation logic from UpdateParticipantSuccessfulDialog and related fragments. 
2. Making navigation to child details from VisitDetailsDialog is now handled by VisitsOverviewFlowActivity
