### PR TITLE
Display the today's scheduled visits as default

### DIFF
--- a/app/src/main/java/com/jnj/vaccinetracker/common/data/database/daos/VisitDao.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/common/data/database/daos/VisitDao.kt
@@ -65,7 +65,7 @@ interface VisitDao : VisitDaoBase<VisitEntity, RoomVisitModel>, ObservableDao, S
             "INNER JOIN visit_attribute va ON v.visitUuid = va.visitUuid AND va.type = 'Visit Status' " +
             "INNER JOIN participant p ON v.participantUuid = p.participantUuid " +
             "WHERE v.startDatetime >=:date AND va.value = :visitStatus AND p.locationUuid = :locationUuid " +
-            "ORDER BY v.startDatetime DESC")
+            "ORDER BY v.startDatetime ASC")
     @Transaction
     suspend fun getScheduledVisits(date: DateEntity, visitStatus: String, locationUuid: String): List<RoomVisitModel>
 

--- a/app/src/main/java/com/jnj/vaccinetracker/common/data/database/daos/VisitDao.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/common/data/database/daos/VisitDao.kt
@@ -64,6 +64,15 @@ interface VisitDao : VisitDaoBase<VisitEntity, RoomVisitModel>, ObservableDao, S
             "FROM visit v " +
             "INNER JOIN visit_attribute va ON v.visitUuid = va.visitUuid AND va.type = 'Visit Status' " +
             "INNER JOIN participant p ON v.participantUuid = p.participantUuid " +
+            "WHERE v.startDatetime >=:date AND va.value = :visitStatus AND p.locationUuid = :locationUuid " +
+            "ORDER BY v.startDatetime DESC")
+    @Transaction
+    suspend fun getScheduledVisits(date: DateEntity, visitStatus: String, locationUuid: String): List<RoomVisitModel>
+
+    @Query("SELECT v.* " +
+            "FROM visit v " +
+            "INNER JOIN visit_attribute va ON v.visitUuid = va.visitUuid AND va.type = 'Visit Status' " +
+            "INNER JOIN participant p ON v.participantUuid = p.participantUuid " +
             "WHERE v.startDatetime BETWEEN :startDate AND :endDate AND va.value = :visitStatus AND p.locationUuid = :locationUuid " +
             "ORDER BY v.startDatetime DESC")
     @Transaction

--- a/app/src/main/java/com/jnj/vaccinetracker/common/data/database/repositories/VisitRepository.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/common/data/database/repositories/VisitRepository.kt
@@ -80,6 +80,10 @@ class VisitRepository @Inject constructor(
         return visitDao.getVisitHistory(date, visitStatus, locationUuid).map { it.toDomain() }
     }
 
+    suspend fun getScheduledVisits(date: DateEntity, visitStatus: String, locationUuid: String): List<Visit> {
+        return visitDao.getScheduledVisits(date, visitStatus, locationUuid).map { it.toDomain() }
+    }
+
     suspend fun getVisitsInDateRange(startDate: DateEntity, endDate: DateEntity, visitStatus: String, locationUuid: String): List<Visit> {
         return visitDao.getVisitsInDateRange(startDate, endDate, visitStatus, locationUuid ).map { it.toDomain() }
     }

--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
@@ -48,17 +48,16 @@ class VisitsListViewModel @Inject constructor(
                 isLoading.value = false
                 return@launch
             }
-            val startDate = getTodayMidnight()
-            val endDate = addDaysToDate(dateNow(), +30)
+            val todayMidnight = getTodayMidnight()
+            val tomorrowMidnight = addDaysToDate(todayMidnight, 1)
 
-            val scheduledVisits = visitRepository.findVisitsInPeriod(startDate, endDate)
-                .filter { it.visitStatus == Constants.VISIT_STATUS_SCHEDULED && participantFromCurrentLocation(it, currentLocationUuid)}
+            val scheduledVisits = visitRepository.getScheduledVisits(todayMidnight, Constants.VISIT_STATUS_SCHEDULED, currentLocationUuid)
 
-            val draftScheduledVisitsEncounter = draftVisitEncounterRepository.findVisitsAfterDate(addDaysToDate(getTodayMidnight(), 1))
+            val draftScheduledVisitsEncounter = draftVisitEncounterRepository.findVisitsAfterDate(tomorrowMidnight)
             val convertedDraftVisitsEncounter = draftScheduledVisitsEncounter.map { draftVisit ->
                 convertDraftVisitEncounterToVisitOffline(draftVisit) }
 
-            val draftScheduledVisits = draftVisitRepository.findVisitsAfterDate(addDaysToDate(getTodayMidnight(), 1))
+            val draftScheduledVisits = draftVisitRepository.findVisitsAfterDate(tomorrowMidnight)
             val convertedDraftVisits = draftScheduledVisits.map { draftVisit ->
                 convertDraftVisitToVisitOffline(draftVisit) }
 
@@ -140,7 +139,7 @@ class VisitsListViewModel @Inject constructor(
             isLoading.value = false
         }
     }
-    
+
     private fun convertDraftVisitToVisitOffline(draftVisit: DraftVisit): Visit {
         return Visit(
             visitUuid = draftVisit.visitUuid,

--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.lifecycle.viewModelScope
-import com.jnj.vaccinetracker.common.data.database.repositories.DraftParticipantRepository
 import com.jnj.vaccinetracker.common.data.database.repositories.DraftVisitEncounterRepository
 import com.jnj.vaccinetracker.common.data.database.repositories.DraftVisitRepository
 import com.jnj.vaccinetracker.common.data.database.repositories.VisitRepository
@@ -22,16 +21,13 @@ import com.jnj.vaccinetracker.common.helpers.AppCoroutineDispatchers
 import com.jnj.vaccinetracker.common.viewmodel.ViewModelWithState
 import com.jnj.vaccinetracker.visitsoverview.dto.VisitDataDTO
 import kotlinx.coroutines.launch
-import java.text.SimpleDateFormat
 import java.util.Date
-import java.util.Locale
 import javax.inject.Inject
 
 class VisitsListViewModel @Inject constructor(
     userRepository: UserRepository,
     private val visitRepository: VisitRepository,
     private val draftVisitRepository: DraftVisitRepository,
-    private  val draftParticipantRepository: DraftParticipantRepository,
     private val draftVisitEncounterRepository: DraftVisitEncounterRepository,
     private val findParticipantByParticipantUuidUseCase: FindParticipantByParticipantUuidUseCase,
     override val dispatchers: AppCoroutineDispatchers
@@ -192,12 +188,6 @@ class VisitsListViewModel @Inject constructor(
     override fun saveInstanceState(outState: Bundle) {}
 
     override fun restoreInstanceState(savedInstanceState: Bundle) {}
-
-    private fun removeTimeFromDateTime(date: Date): String {
-        val sdf = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
-        val dateStr = sdf.format(date)
-        return dateStr
-    }
 
     private suspend fun participantFromCurrentLocation(visit: Visit, locationUuid: String): Boolean {
         val participant = findParticipantByParticipantUuidUseCase.findByParticipantUuid(visit.participantUuid)

--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/screens/VisitsListFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/screens/VisitsListFragment.kt
@@ -49,8 +49,8 @@ class VisitsListFragment(private val visitsKey: String) : BaseFragment(),
     private lateinit var binding: FragmentVisitsListBinding
     private lateinit var visitsAdapter: VisitsAdapter
     private val visitsListViewModel: VisitsListViewModel by viewModels { viewModelFactory }
-    private var selectedStartDate: DateTime? = null
-    private var selectedEndDate: DateTime? = null
+    private var selectedStartDate: DateTime? = DateTime.now()
+    private var selectedEndDate: DateTime? = DateTime.now()
 
     @Inject lateinit var configurationManager: ConfigurationManager
     @Inject lateinit var visitManager: VisitManager
@@ -62,6 +62,9 @@ class VisitsListFragment(private val visitsKey: String) : BaseFragment(),
     ): View {
         setHasOptionsMenu(true)
         binding = DataBindingUtil.inflate(inflater, R.layout.fragment_visits_list, container, false)
+
+        binding.labelStartDate.text = formatDate(selectedStartDate)
+        binding.labelEndDate.text = formatDate(selectedEndDate)
 
         setupRecyclerView()
         loadVisitsData()

--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/screens/VisitsListFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/screens/VisitsListFragment.kt
@@ -49,7 +49,7 @@ class VisitsListFragment(private val visitsKey: String) : BaseFragment(),
     private lateinit var binding: FragmentVisitsListBinding
     private lateinit var visitsAdapter: VisitsAdapter
     private val visitsListViewModel: VisitsListViewModel by viewModels { viewModelFactory }
-    private var selectedStartDate: DateTime? =null
+    private var selectedStartDate: DateTime? = null
     private var selectedEndDate: DateTime? = null
 
     @Inject lateinit var configurationManager: ConfigurationManager

--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/screens/VisitsListFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/screens/VisitsListFragment.kt
@@ -49,8 +49,8 @@ class VisitsListFragment(private val visitsKey: String) : BaseFragment(),
     private lateinit var binding: FragmentVisitsListBinding
     private lateinit var visitsAdapter: VisitsAdapter
     private val visitsListViewModel: VisitsListViewModel by viewModels { viewModelFactory }
-    private var selectedStartDate: DateTime? = DateTime.now()
-    private var selectedEndDate: DateTime? = DateTime.now()
+    private var selectedStartDate: DateTime? =null
+    private var selectedEndDate: DateTime? = null
 
     @Inject lateinit var configurationManager: ConfigurationManager
     @Inject lateinit var visitManager: VisitManager
@@ -62,10 +62,6 @@ class VisitsListFragment(private val visitsKey: String) : BaseFragment(),
     ): View {
         setHasOptionsMenu(true)
         binding = DataBindingUtil.inflate(inflater, R.layout.fragment_visits_list, container, false)
-
-        binding.labelStartDate.text = formatDate(selectedStartDate)
-        binding.labelEndDate.text = formatDate(selectedEndDate)
-
         setupRecyclerView()
         loadVisitsData()
         setupObservers()
@@ -104,7 +100,13 @@ class VisitsListFragment(private val visitsKey: String) : BaseFragment(),
 
     private fun loadVisitsData() {
         when (visitsKey) {
-            Constants.VISITS_OVERVIEW_SCHEDULED_VISITS_KEY -> visitsListViewModel.getScheduledVisitsData()
+            Constants.VISITS_OVERVIEW_SCHEDULED_VISITS_KEY -> {
+                selectedStartDate = DateTime.now()
+                selectedEndDate = DateTime.now()
+                binding.labelStartDate.text = formatDate(selectedStartDate)
+                binding.labelEndDate.text = formatDate(selectedEndDate)
+                visitsListViewModel.getScheduledVisitsData()
+            }
             Constants.VISITS_OVERVIEW_HISTORICAL_VISITS_KEY -> visitsListViewModel.getHistoricalVisitsData()
             Constants.VISITS_OVERVIEW_MISSED_VISITS_KEY -> visitsListViewModel.getMissedVisitsData()
         }


### PR DESCRIPTION
# This PR focuses on;

This PR changes the default behavior of the visits list screen to display today's scheduled visits instead of no initial filter.

1. Initialize date filters to current date instead of null values
2. Update UI labels to show the selected date range on screen load
3. Optimize data fetching to retrieve only today's scheduled visits using a new database query
4. Not to fetch and visits before today