### PR TITLE
Deleting a participant by both UUID and ID

### DIFF
--- a/app/src/main/java/com/jnj/vaccinetracker/common/data/database/repositories/ParticipantRepository.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/common/data/database/repositories/ParticipantRepository.kt
@@ -113,10 +113,14 @@ class ParticipantRepository @Inject constructor(
     override suspend fun insert(model: Participant, orReplace: Boolean) = transactionRunner.withTransaction {
         try {
             if (orReplace) {
-                //we assume due to foreign keys, the related child rows will be deleted as well
-                val isDeleted = participantDao.deleteByParticipantUuid(model.participantUuid) > 0
-                if (isDeleted) {
-                    logInfo("deleted participant for replace ${model.participantUuid}")
+                // Delete by UUID
+                val isDeletedByUuid = participantDao.deleteByParticipantUuid(model.participantUuid) > 0
+                // Also delete by participantId to avoid UNIQUE constraint violation
+                val isDeletedById = participantDao.findByParticipantId(model.participantId)?.let {
+                    participantDao.deleteByParticipantUuid(it.participantUuid) > 0
+                } ?: false
+                if (isDeletedByUuid || isDeletedById) {
+                    logInfo("deleted participant for replace ${model.participantUuid} or participantId ${model.participantId}")
                 }
             }
 

--- a/app/src/main/java/com/jnj/vaccinetracker/common/data/database/repositories/ParticipantRepository.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/common/data/database/repositories/ParticipantRepository.kt
@@ -113,16 +113,10 @@ class ParticipantRepository @Inject constructor(
     override suspend fun insert(model: Participant, orReplace: Boolean) = transactionRunner.withTransaction {
         try {
             if (orReplace) {
-                val isDeletedByUuid = participantDao.deleteByParticipantUuid(model.participantUuid) > 0
-                val isDeletedById = participantDao.findByParticipantId(model.participantId)?.let {
-                    if (it.participantUuid != model.participantUuid) {
-                        participantDao.deleteByParticipantUuid(it.participantUuid) > 0
-                    } else {
-                        false
-                    }
-                } ?: false
-                if (isDeletedByUuid || isDeletedById) {
-                    logInfo("deleted participant for replace ${model.participantUuid} or participantId ${model.participantId}")
+                //we assume due to foreign keys, the related child rows will be deleted as well
+                val isDeleted = participantDao.deleteByParticipantUuid(model.participantUuid) > 0
+                if (isDeleted) {
+                    logInfo("deleted participant for replace ${model.participantUuid}")
                 }
             }
 

--- a/app/src/main/java/com/jnj/vaccinetracker/common/data/database/repositories/ParticipantRepository.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/common/data/database/repositories/ParticipantRepository.kt
@@ -113,10 +113,16 @@ class ParticipantRepository @Inject constructor(
     override suspend fun insert(model: Participant, orReplace: Boolean) = transactionRunner.withTransaction {
         try {
             if (orReplace) {
-                //we assume due to foreign keys, the related child rows will be deleted as well
-                val isDeleted = participantDao.deleteByParticipantUuid(model.participantUuid) > 0
-                if (isDeleted) {
-                    logInfo("deleted participant for replace ${model.participantUuid}")
+                val isDeletedByUuid = participantDao.deleteByParticipantUuid(model.participantUuid) > 0
+                val isDeletedById = participantDao.findByParticipantId(model.participantId)?.let {
+                    if (it.participantUuid != model.participantUuid) {
+                        participantDao.deleteByParticipantUuid(it.participantUuid) > 0
+                    } else {
+                        false
+                    }
+                } ?: false
+                if (isDeletedByUuid || isDeletedById) {
+                    logInfo("deleted participant for replace ${model.participantUuid} or participantId ${model.participantId}")
                 }
             }
 

--- a/app/src/main/java/com/jnj/vaccinetracker/common/data/database/repositories/ParticipantRepository.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/common/data/database/repositories/ParticipantRepository.kt
@@ -117,7 +117,11 @@ class ParticipantRepository @Inject constructor(
                 val isDeletedByUuid = participantDao.deleteByParticipantUuid(model.participantUuid) > 0
                 // Also delete by participantId to avoid UNIQUE constraint violation
                 val isDeletedById = participantDao.findByParticipantId(model.participantId)?.let {
-                    participantDao.deleteByParticipantUuid(it.participantUuid) > 0
+                    if (it.participantUuid != model.participantUuid) {
+                        participantDao.deleteByParticipantUuid(it.participantUuid) > 0
+                    } else {
+                        false
+                    }
                 } ?: false
                 if (isDeletedByUuid || isDeletedById) {
                     logInfo("deleted participant for replace ${model.participantUuid} or participantId ${model.participantId}")

--- a/app/src/main/java/com/jnj/vaccinetracker/common/data/database/repositories/ParticipantRepository.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/common/data/database/repositories/ParticipantRepository.kt
@@ -113,9 +113,7 @@ class ParticipantRepository @Inject constructor(
     override suspend fun insert(model: Participant, orReplace: Boolean) = transactionRunner.withTransaction {
         try {
             if (orReplace) {
-                // Delete by UUID
                 val isDeletedByUuid = participantDao.deleteByParticipantUuid(model.participantUuid) > 0
-                // Also delete by participantId to avoid UNIQUE constraint violation
                 val isDeletedById = participantDao.findByParticipantId(model.participantId)?.let {
                     if (it.participantUuid != model.participantUuid) {
                         participantDao.deleteByParticipantUuid(it.participantUuid) > 0


### PR DESCRIPTION
# This PR focuses on;

1. The participant deletion logic during replacement operations to handle both UUID and participant ID constraints.
2. The change prevents UNIQUE constraint violations by ensuring that existing participants with the same participantId and same UUID are removed before inserting a replacement participant.

**Key Changes**

1. Modified the deletion logic to check for existing participants by both UUID and participant ID
2. Added secondary deletion step to remove participants found by participant ID to prevent constraint violations