### PR TITLE
Feature/default todays visit history

### DIFF
--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
@@ -81,17 +81,12 @@ class VisitsListViewModel @Inject constructor(
                 return@launch
             }
 
-            val startDate = addDaysToDate(dateNow(), -30)
-            val endDate = addDaysToDate(getTodayMidnight(), 1)
+            val todayMidnight = getTodayMidnight()
+            val tomorrowMidnight = addDaysToDate(todayMidnight, 1)
 
-            val historicalVisits = visitRepository.getVisitsInDateRange(
-                startDate,
-                endDate,
-                Constants.VISIT_STATUS_OCCURRED,
-                currentLocationUuid
-            )
+            val historicalVisits = visitRepository.getVisitHistory(tomorrowMidnight, Constants.VISIT_STATUS_OCCURRED, currentLocationUuid)
 
-            val draftHistoricalVisitsEncounter = draftVisitEncounterRepository.findVisitsBeforeDate(addDaysToDate(getTodayMidnight(), 1))
+            val draftHistoricalVisitsEncounter = draftVisitEncounterRepository.findVisitsBeforeDate(tomorrowMidnight)
             val convertedDraftVisitsEncounter = draftHistoricalVisitsEncounter.map { draftVisitEncounter ->
                 convertDraftVisitEncounterToVisitOffline(draftVisitEncounter)}
 

--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/screens/VisitsListFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/screens/VisitsListFragment.kt
@@ -101,13 +101,11 @@ class VisitsListFragment(private val visitsKey: String) : BaseFragment(),
     private fun loadVisitsData() {
         when (visitsKey) {
             Constants.VISITS_OVERVIEW_SCHEDULED_VISITS_KEY -> {
-                selectedStartDate = DateTime.now()
-                selectedEndDate = DateTime.now()
-                binding.labelStartDate.text = formatDate(selectedStartDate)
-                binding.labelEndDate.text = formatDate(selectedEndDate)
-                visitsListViewModel.getScheduledVisitsData()
+                setDateLabelsAndLoadData { visitsListViewModel.getScheduledVisitsData() }
             }
-            Constants.VISITS_OVERVIEW_HISTORICAL_VISITS_KEY -> visitsListViewModel.getHistoricalVisitsData()
+            Constants.VISITS_OVERVIEW_HISTORICAL_VISITS_KEY -> {
+                setDateLabelsAndLoadData { visitsListViewModel.getHistoricalVisitsData() }
+            }
             Constants.VISITS_OVERVIEW_MISSED_VISITS_KEY -> visitsListViewModel.getMissedVisitsData()
         }
     }
@@ -122,6 +120,14 @@ class VisitsListFragment(private val visitsKey: String) : BaseFragment(),
         visitsListViewModel.isLoading.observe(viewLifecycleOwner) { isLoading ->
             binding.progressBar.visibility = if (isLoading == true) View.VISIBLE else View.GONE
         }
+    }
+
+    private fun setDateLabelsAndLoadData(loadData: () -> Unit) {
+        selectedStartDate = DateTime.now()
+        selectedEndDate = DateTime.now()
+        binding.labelStartDate.text = formatDate(selectedStartDate)
+        binding.labelEndDate.text = formatDate(selectedEndDate)
+        loadData()
     }
 
     private fun setupFilterButtons() {


### PR DESCRIPTION
# This PR focuses on;

1. Default list in the visit history report are visits that happened today at that facility
2. Pulling all visits  from the backend
3. Enable the start and end date filter buttons to pull more information when the dates are changes