### PR TITLE
Default missed visit list to yesterdays missed visits

### DIFF
--- a/app/src/main/java/com/jnj/vaccinetracker/common/data/database/daos/VisitDao.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/common/data/database/daos/VisitDao.kt
@@ -58,6 +58,15 @@ interface VisitDao : VisitDaoBase<VisitEntity, RoomVisitModel>, ObservableDao, S
             "WHERE v.startDatetime <= :date AND va.value = :visitStatus AND p.locationUuid = :locationUuid " +
             "ORDER BY v.startDatetime DESC")
     @Transaction
+    suspend fun getMissedVisits(date: DateEntity, visitStatus: String, locationUuid: String): List<RoomVisitModel>
+
+    @Query("SELECT v.* " +
+            "FROM visit v " +
+            "INNER JOIN visit_attribute va ON v.visitUuid = va.visitUuid AND va.type = 'Visit Status' " +
+            "INNER JOIN participant p ON v.participantUuid = p.participantUuid " +
+            "WHERE v.startDatetime <= :date AND va.value = :visitStatus AND p.locationUuid = :locationUuid " +
+            "ORDER BY v.startDatetime DESC")
+    @Transaction
     suspend fun getVisitHistory(date: DateEntity, visitStatus: String, locationUuid: String): List<RoomVisitModel>
 
     @Query("SELECT v.* " +

--- a/app/src/main/java/com/jnj/vaccinetracker/common/data/database/repositories/VisitRepository.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/common/data/database/repositories/VisitRepository.kt
@@ -76,6 +76,10 @@ class VisitRepository @Inject constructor(
         return visitDao.findVisitsBeforeDate(date, visitStatus).map { it.toDomain() }
     }
 
+    suspend fun getMissedVisits(date: DateEntity, visitStatus: String, locationUuid: String): List<Visit> {
+        return visitDao.getMissedVisits(date, visitStatus, locationUuid).map { it.toDomain() }
+    }
+
     suspend fun getVisitHistory(date: DateEntity, visitStatus: String, locationUuid: String): List<Visit> {
         return visitDao.getVisitHistory(date, visitStatus, locationUuid).map { it.toDomain() }
     }

--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
@@ -112,21 +112,15 @@ class VisitsListViewModel @Inject constructor(
                 isLoading.value = false
                 return@launch
             }
+            val todayMidnight = getTodayMidnight()
 
-            val startDate = addDaysToDate(dateNow(), -30)
-            val endDate = getTodayMidnight()
-
-            val missedVisits = visitRepository.findVisitsInPeriod(startDate, endDate)
-                .filter { it.visitStatus == Constants.VISIT_STATUS_SCHEDULED && participantFromCurrentLocation(it, currentLocationUuid)}
-
-            val draftVisits = draftVisitRepository.findVisitsBeforeDate(getTodayMidnight())
-            val convertedDraftVisits = draftVisits.map { draftVisit ->
-                convertDraftVisitToVisitOffline(draftVisit)
-            }
+            val missedVisits = visitRepository.getMissedVisits(todayMidnight, Constants.VISIT_STATUS_SCHEDULED, currentLocationUuid )
+            val draftVisits = draftVisitRepository.findVisitsBeforeDate(todayMidnight)
+            val convertedDraftVisits = draftVisits.map { draftVisit -> convertDraftVisitToVisitOffline(draftVisit) }
 
             val combinedMissedVisits =  missedVisits + convertedDraftVisits
 
-            val draftScheduledVisits = draftVisitRepository.findVisitsAfterDate(getTodayMidnight())
+            val draftScheduledVisits = draftVisitRepository.findVisitsAfterDate(todayMidnight)
             val filteredMissedVisits = combinedMissedVisits.filter { missedVisit ->
                 missedVisit.participantUuid !in draftScheduledVisits.map { it.participantUuid }
             }

--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/screens/VisitsListFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/screens/VisitsListFragment.kt
@@ -107,8 +107,13 @@ class VisitsListFragment(private val visitsKey: String) : BaseFragment(),
             Constants.VISITS_OVERVIEW_HISTORICAL_VISITS_KEY -> {
                 setDateLabelsAndLoadData { visitsListViewModel.getHistoricalVisitsData() }
             }
-            Constants.VISITS_OVERVIEW_MISSED_VISITS_KEY -> visitsListViewModel.getMissedVisitsData()
-
+            Constants.VISITS_OVERVIEW_MISSED_VISITS_KEY -> {
+                selectedStartDate = DateTime.now() - 1.days
+                selectedEndDate = DateTime.now() - 1.days
+                binding.labelStartDate.text = formatDate(selectedStartDate)
+                binding.labelEndDate.text = formatDate(selectedEndDate)
+                visitsListViewModel.getMissedVisitsData()
+            }
         }
     }
 

--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/screens/VisitsListFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/screens/VisitsListFragment.kt
@@ -33,6 +33,7 @@ import com.soywiz.klock.DateTime
 import com.soywiz.klock.jvm.toDate
 import kotlinx.coroutines.launch
 import org.apache.poi.hssf.usermodel.HSSFWorkbook
+import com.soywiz.klock.days
 import java.time.ZoneId
 import java.util.Locale
 import javax.inject.Inject
@@ -108,7 +109,13 @@ class VisitsListFragment(private val visitsKey: String) : BaseFragment(),
                 visitsListViewModel.getScheduledVisitsData()
             }
             Constants.VISITS_OVERVIEW_HISTORICAL_VISITS_KEY -> visitsListViewModel.getHistoricalVisitsData()
-            Constants.VISITS_OVERVIEW_MISSED_VISITS_KEY -> visitsListViewModel.getMissedVisitsData()
+            Constants.VISITS_OVERVIEW_MISSED_VISITS_KEY -> {
+                selectedStartDate = DateTime.now() - 1.days
+                selectedEndDate = DateTime.now() - 1.days
+                binding.labelStartDate.text = formatDate(selectedStartDate)
+                binding.labelEndDate.text = formatDate(selectedEndDate)
+                visitsListViewModel.getMissedVisitsData()
+            }
         }
     }
 


### PR DESCRIPTION
# This PR focuses on;

1. Default list in the missed visits report are visits that happened were missed yesterday
2. Pulling all visits from the backend
3. Enable the start and end date filter buttons to pull more information when the dates are changes