### PR TITLE
Old scheduled visits appear in the scheduled visits report

### DIFF
--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
@@ -49,23 +49,16 @@ class VisitsListViewModel @Inject constructor(
 
             val scheduledVisits = visitRepository.getScheduledVisits(todayMidnight, Constants.VISIT_STATUS_SCHEDULED, currentLocationUuid)
 
-            val draftScheduledVisitsEncounter = draftVisitEncounterRepository.findVisitsAfterDate(tomorrowMidnight)
-            val convertedDraftVisitsEncounter = draftScheduledVisitsEncounter.map { draftVisit ->
-                convertDraftVisitEncounterToVisitOffline(draftVisit) }
-
             val draftScheduledVisits = draftVisitRepository.findVisitsAfterDate(tomorrowMidnight)
             val convertedDraftVisits = draftScheduledVisits.map { draftVisit ->
                 convertDraftVisitToVisitOffline(draftVisit) }
-
-            val filteredScheduleDraftVisitsEncounter = convertedDraftVisitsEncounter.filter { draftVisitEncounter ->
-                draftVisitEncounter.participantUuid !in convertedDraftVisits.map { it.participantUuid } }
 
             // Remove scheduled visits with the same participant ID as in draftVisitEncounter
             val draftVisitParticipantIds = draftScheduledVisitsEncounter.map { it.participantUuid }.toSet()
             val filteredScheduledVisits = scheduledVisits.filter { scheduledVisit ->
                 !draftVisitParticipantIds.contains(scheduledVisit.participantUuid) }
 
-            val combinedScheduledVisits = convertedDraftVisits + filteredScheduleDraftVisitsEncounter + filteredScheduledVisits
+            val combinedScheduledVisits = convertedDraftVisits + filteredScheduledVisits
             visitDTOs.value = createVisitDTOList(combinedScheduledVisits)
             isLoading.value = false
         }

--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
@@ -48,15 +48,11 @@ class VisitsListViewModel @Inject constructor(
             val tomorrowMidnight = addDaysToDate(todayMidnight, 1)
 
             val scheduledVisits = visitRepository.getScheduledVisits(todayMidnight, Constants.VISIT_STATUS_SCHEDULED, currentLocationUuid)
+            val draftVisits = draftVisitRepository.findVisitsAfterDate(tomorrowMidnight)
+            val convertedDraftVisits = draftVisits.map { draftVisit -> convertDraftVisitToVisitOffline(draftVisit) }
 
-            val draftScheduledVisits = draftVisitRepository.findVisitsAfterDate(tomorrowMidnight)
-            val convertedDraftVisits = draftScheduledVisits.map { draftVisit ->
-                convertDraftVisitToVisitOffline(draftVisit) }
-
-            // Remove scheduled visits with the same participant ID as in draftVisitEncounter
-            val draftVisitParticipantIds = draftScheduledVisitsEncounter.map { it.participantUuid }.toSet()
-            val filteredScheduledVisits = scheduledVisits.filter { scheduledVisit ->
-                !draftVisitParticipantIds.contains(scheduledVisit.participantUuid) }
+            val draftVisitParticipantIds = convertedDraftVisits.map { it.participantUuid }.toSet()
+            val filteredScheduledVisits = scheduledVisits.filter { scheduledVisit -> !draftVisitParticipantIds.contains(scheduledVisit.participantUuid) }
 
             val combinedScheduledVisits = convertedDraftVisits + filteredScheduledVisits
             visitDTOs.value = createVisitDTOList(combinedScheduledVisits)

--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
@@ -47,18 +47,25 @@ class VisitsListViewModel @Inject constructor(
             val tomorrowMidnight = addDaysToDate(todayMidnight, 1)
 
             val scheduledVisits = visitRepository.getScheduledVisits(todayMidnight, Constants.VISIT_STATUS_SCHEDULED, currentLocationUuid)
+            val uniqueScheduledVisits = scheduledVisits
+                .groupBy { it.participantUuid }
+                .map { (_, visits) ->
+                    visits
+                        .sortedWith(compareByDescending<Visit> { it.startDatetime.time }.thenByDescending { it.visitType != null })
+                        .first()
+                }
+
             val draftVisits = draftVisitRepository.findVisitsAfterDate(tomorrowMidnight)
-            val convertedDraftVisits = draftVisits.map { draftVisit -> convertDraftVisitToVisitOffline(draftVisit) }
+            val convertedDraftVisits = draftVisits.map { convertDraftVisitToVisitOffline(it) }
 
             val draftVisitParticipantIds = convertedDraftVisits.map { it.participantUuid }.toSet()
-            val filteredScheduledVisits = scheduledVisits.filter { scheduledVisit -> !draftVisitParticipantIds.contains(scheduledVisit.participantUuid) }
+            val filteredScheduledVisits = uniqueScheduledVisits.filter { scheduledVisit -> !draftVisitParticipantIds.contains(scheduledVisit.participantUuid)}
 
             val combinedScheduledVisits = convertedDraftVisits + filteredScheduledVisits
             visitDTOs.value = createVisitDTOList(combinedScheduledVisits)
             isLoading.value = false
         }
     }
-
     @RequiresApi(Build.VERSION_CODES.O)
     fun getHistoricalVisitsData() {
         isLoading.value = true

--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
@@ -8,7 +8,6 @@ import com.jnj.vaccinetracker.common.data.database.repositories.DraftVisitEncoun
 import com.jnj.vaccinetracker.common.data.database.repositories.DraftVisitRepository
 import com.jnj.vaccinetracker.common.data.database.repositories.VisitRepository
 import com.jnj.vaccinetracker.common.data.database.typealiases.addDaysToDate
-import com.jnj.vaccinetracker.common.data.database.typealiases.dateNow
 import com.jnj.vaccinetracker.common.data.database.typealiases.getTodayMidnight
 import com.jnj.vaccinetracker.common.data.models.Constants
 import com.jnj.vaccinetracker.common.data.repositories.UserRepository
@@ -166,15 +165,4 @@ class VisitsListViewModel @Inject constructor(
     override fun saveInstanceState(outState: Bundle) {}
 
     override fun restoreInstanceState(savedInstanceState: Bundle) {}
-
-    private suspend fun participantFromCurrentLocation(visit: Visit, locationUuid: String): Boolean {
-        val participant = findParticipantByParticipantUuidUseCase.findByParticipantUuid(visit.participantUuid)
-        return if (participant == null) {
-            Log.w("VisitsListViewModel", "Participant not found for UUID: ${visit.participantUuid}")
-            false
-        } else {
-            Log.d("VisitsListViewModel", "Participant found: ${participant.participantUuid}, Location UUID: ${participant.locationUuid} vs Current Location UUID: $locationUuid")
-            participant.locationUuid == locationUuid
-        }
-    }
 }


### PR DESCRIPTION
# This PR focuses;

1. Removing the draft visit encounter because it contains visits with a status of occurred
2. Filtering using draft visits to remove the duplicated visits
3. Removing unused import and function