### PR TITLE
Validate birth weight field after press register button

### DIFF
--- a/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantParticipantDetailsViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantParticipantDetailsViewModel.kt
@@ -380,7 +380,7 @@ class RegisterParticipantParticipantDetailsViewModel @Inject constructor(
 
         val areInputsValid = validateInputs(participantId, gender, birthDate, homeLocation,
             motherFirstName, motherLastName, fatherFirstName, fatherLastName, childFirstName,
-            childLastName, childNumber)
+            childLastName, childNumber, birthWeight)
         val isNinValid = isNinValueValid(nin)
 
         var phoneNumberToSubmit: String? = null
@@ -581,7 +581,8 @@ class RegisterParticipantParticipantDetailsViewModel @Inject constructor(
         fatherLastName: String?,
         childFirstName: String?,
         childLastName: String?,
-        childNumber: String?
+        childNumber: String?,
+        birthWeight: String?
     ): Boolean {
         var isValid = true
         val validationErrors: MutableList<String> = mutableListOf()
@@ -616,6 +617,22 @@ class RegisterParticipantParticipantDetailsViewModel @Inject constructor(
             }
         }
 
+        addValidationError(
+            !birthWeight.isNullOrEmpty(),
+            R.string.participant_registration_details_error_invalid_birth_weight,
+            birthWeightValidationMessage
+        )
+
+        if (!birthWeight.isNullOrEmpty()) {
+            val weight = birthWeight.toDoubleOrNull()
+            if (weight == null || weight < 0.1 || weight > 8.0) {
+                addValidationError(
+                    false,
+                    R.string.participant_registration_details_error_invalid_birth_weight,
+                    birthWeightValidationMessage
+                )
+            }
+        }
 
         addValidationError(!childNumber.isNullOrEmpty(), R.string.participant_registration_details_error_no_child_number, childNumberValidationMessage)
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -387,6 +387,7 @@
     <string name="participant_registration_details_error_nin_already_exist">National ID is already in use. Please use different one</string>
     <string name="visit_z_score_weight_label">Weight for Age</string>
     <string name="participant_registration_details_error_birth_date_cannot_be_empty">Fill in Date of Birth OR Estimated Age</string>
+    <string name="participant_registration_details_error_invalid_birth_weight">Enter the birth weight between 0.1 and 8.0 like 2.8</string>
     <string name="visit_z_score_label">Z Score</string>
     <string name="visit_dosing_error_no_weight">Please enter weight</string>
     <string name="visit_z_score_height_label">Height for age</string>


### PR DESCRIPTION
# This PR focuses on;

This PR adds validation for the birth weight field during participant registration, ensuring the value is within the valid range of 0.1 to 8.0 kg when the register button is pressed.

- Added birth weight validation with range checking (0.1 to 8.0)
- Added error message string for invalid birth weight values
- Updated validation method to include birth weight parameter

###  Changes


| File | Description |
| ---- | ----------- |
| strings.xml | Added error message for invalid birth weight range |
| RegisterParticipantParticipantDetailsViewModel.kt | Updated validation logic to include birth weight range checking |

