### PR TITLE
Confirm visit location or place on login

### DIFF
--- a/app/src/main/java/com/jnj/vaccinetracker/login/LoginActivity.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/login/LoginActivity.kt
@@ -185,7 +185,7 @@ class LoginActivity : BaseActivity() {
             getString(R.string.confirm_visit_place_message, visitPlace)
         }
 
-        androidx.appcompat.app.AlertDialog.Builder(this)
+        AlertDialog.Builder(this)
             .setTitle(R.string.confirm_visit_place_title)
             .setMessage(message)
             .setPositiveButton(R.string.confirm) { _, _ ->

--- a/app/src/main/java/com/jnj/vaccinetracker/login/LoginActivity.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/login/LoginActivity.kt
@@ -13,6 +13,7 @@ import android.widget.ArrayAdapter
 import android.widget.ImageView
 import androidx.activity.viewModels
 import androidx.annotation.RequiresApi
+import androidx.appcompat.app.AlertDialog
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.LifecycleOwner
 import com.google.android.material.textfield.TextInputEditText
@@ -172,7 +173,6 @@ class LoginActivity : BaseActivity() {
         if ((selectedVisitPlace == Constants.VISIT_PLACE_OUTREACH) && (outreachName.isEmpty())) {
             binding.editOutreachName.error = resourcesWrapper.getString(R.string.login_label_validation_no_outreach_name)
             return
-        }
         } else {
             showConfirmVisitPlaceDialog(username, password, visitPlace, outreachName)
         }

--- a/app/src/main/java/com/jnj/vaccinetracker/login/LoginActivity.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/login/LoginActivity.kt
@@ -168,13 +168,28 @@ class LoginActivity : BaseActivity() {
         val password = binding.editPassword.text.toString()
         val visitPlace = binding.dropdownLoginVisitPlace.text.toString()
         val outreachName = binding.editOutreachName.text.toString().uppercase()
-        if((selectedVisitPlace == Constants.VISIT_PLACE_OUTREACH) && (outreachName.isEmpty())){
+
+        if ((selectedVisitPlace == Constants.VISIT_PLACE_OUTREACH) && (outreachName.isEmpty())) {
             binding.editOutreachName.error = resourcesWrapper.getString(R.string.login_label_validation_no_outreach_name)
-        } else {
-            val defaultOutreachName = outreachName.ifEmpty { "No Outreach" }
-            saveVisitPlaceToMemory(visitPlace, defaultOutreachName)
-            viewModel.login(username, password, visitPlace)
+            return
         }
+
+        val message = if (selectedVisitPlace == Constants.VISIT_PLACE_OUTREACH) {
+            getString(R.string.confirm_visit_place_message_with_outreach, visitPlace, outreachName)
+        } else {
+            getString(R.string.confirm_visit_place_message, visitPlace)
+        }
+
+        androidx.appcompat.app.AlertDialog.Builder(this)
+            .setTitle(R.string.confirm_visit_place_title)
+            .setMessage(message)
+            .setPositiveButton(R.string.confirm) { _, _ ->
+                val defaultOutreachName = outreachName.ifEmpty { "No Outreach" }
+                saveVisitPlaceToMemory(visitPlace, defaultOutreachName)
+                viewModel.login(username, password, visitPlace)
+            }
+            .setNegativeButton(R.string.cancel, null)
+            .show()
     }
 
     @RequiresApi(Build.VERSION_CODES.O)

--- a/app/src/main/java/com/jnj/vaccinetracker/login/LoginActivity.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/login/LoginActivity.kt
@@ -173,7 +173,12 @@ class LoginActivity : BaseActivity() {
             binding.editOutreachName.error = resourcesWrapper.getString(R.string.login_label_validation_no_outreach_name)
             return
         }
+        } else {
+            showConfirmVisitPlaceDialog(username, password, visitPlace, outreachName)
+        }
+    }
 
+    private fun showConfirmVisitPlaceDialog(username: String, password: String, visitPlace: String, outreachName: String) {
         val message = if (selectedVisitPlace == Constants.VISIT_PLACE_OUTREACH) {
             getString(R.string.confirm_visit_place_message_with_outreach, visitPlace, outreachName)
         } else {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,6 +64,11 @@
     <string name="login_label_validation_no_password">Please enter your password</string>
     <string name="login_label_validation_no_visit_place">Please select visit place</string>
     <string name="login_label_validation_no_outreach_name" translatable="false">Please enter an outreach name</string>
+    <string name="confirm_visit_place_title">Confirm Visit Place</string>
+    <string name="confirm_visit_place_message">You selected: %1$s\nDo you want to proceed?</string>
+    <string name="confirm_visit_place_message_with_outreach">You selected: %1$s\nOutreach Name: %2$s\nDo you want to proceed?</string>
+    <string name="confirm">Confirm</string>
+    <string name="cancel">Cancel</string>
     <string name="login_label_validation_no_backend_url">Please enter a valid backend URL</string>
     <string name="dialog_login_title">Session expired</string>
     <string name="dialog_login_description">Your session has expired. Please provide operator password to logon again or terminate current session.</string>


### PR DESCRIPTION
# This PR focuses on;

This PR adds a confirmation dialog to verify the selected visit location before proceeding with login. The enhancement improves user experience by allowing users to confirm their visit place selection and outreach name before authentication.

- Adds confirmation dialog strings for visit place verification
- Implements AlertDialog to confirm visit place selection on login
- Handles both regular visit places and outreach locations with appropriate messaging

### Changes

| File | Description |
| ---- | ----------- |
| strings.xml | Adds string resources for confirmation dialog title, messages, and button labels |
| LoginActivity.kt | Implements confirmation dialog logic in login flow with conditional messaging |
