### PR TITLE
Landscape and mobile sync error popup

### DIFF
--- a/app/src/main/res/layout-sw600dp/dialog_sync_error.xml
+++ b/app/src/main/res/layout-sw600dp/dialog_sync_error.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="viewModel"
+            type="com.jnj.vaccinetracker.common.ui.dialog.SyncErrorViewModel" />
+
+        <import type="android.view.View" />
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <TextView
+                android:id="@+id/label_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:gravity="center_horizontal"
+                android:text="@string/sync_error_dialog_title"
+                android:textAppearance="@style/ScreenTitle" />
+
+            <ProgressBar
+                android:id="@+id/progress_bar"
+                style="?android:attr/progressBarStyleHorizontal"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:indeterminate="true"
+                android:visibility="@{viewModel.loading ? View.VISIBLE : View.INVISIBLE}" />
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:layout_gravity="center"
+                android:paddingStart="16dp"
+                android:paddingEnd="16dp">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="8dp"
+                    android:text="@string/sync_error_dialog_last_sync_date_label"
+                    android:textAppearance="@style/LabelText"/>
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@{viewModel.lastSyncDate!=null ? viewModel.lastSyncDate.displayDate : @string/general_label_na}"
+                    tools:text="2021-05-02 10:30"
+                    android:textAppearance="@style/GeneralText"/>
+            </LinearLayout>
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recyclerView_sync_errors"
+                android:layout_width="wrap_content"
+                android:layout_height="0dp"
+                android:layout_marginStart="32dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="32dp"
+                android:layout_marginBottom="16dp"
+                android:layout_weight="1"
+                android:background="@drawable/white_with_stroke"
+                android:orientation="vertical"
+                android:paddingTop="2dp"
+                android:paddingBottom="2dp"
+                android:scrollbarSize="2dp"
+                android:scrollbarThumbVertical="@color/colorSecondary"
+                android:scrollbars="vertical"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                tools:listitem="@layout/item_sync_error" />
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="32dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginBottom="16dp"
+                android:gravity="top|end"
+                android:orientation="horizontal">
+
+                <Button
+                    android:id="@+id/btn_delete_all"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="16dp"
+                    android:backgroundTint="@color/alertLight"
+                    android:textAppearance="@style/ButtonTextStyling"
+                    android:enabled="@{viewModel.loading ? false : true }"
+                    android:text="@string/sync_error_btn_delete_all"
+                    android:visibility="@{viewModel.showDeleteAllSyncErrorsButton ? View.VISIBLE : View.GONE }" />
+
+                <Button
+                    android:id="@+id/btn_share"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="16dp"
+                    android:enabled="@{viewModel.loading ? false : true }"
+                    android:text="@string/sync_error_btn_share"
+                    android:backgroundTint="@color/colorPrimary"
+                    android:textAppearance="@style/ButtonTextStyling"
+                    android:visibility="@{viewModel.showShareButton ? View.VISIBLE : View.GONE }" />
+
+                <Button
+                    android:id="@+id/btn_finish"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:backgroundTint="@color/colorPrimary"
+                    android:textAppearance="@style/ButtonTextStyling"
+                    android:text="@string/general_label_close" />
+            </LinearLayout>
+        </LinearLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+</layout>

--- a/app/src/main/res/layout/dialog_sync_error.xml
+++ b/app/src/main/res/layout/dialog_sync_error.xml
@@ -28,7 +28,7 @@
 
             <TextView
                 android:id="@+id/label_title"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="16dp"
@@ -50,7 +50,8 @@
                 android:layout_height="wrap_content"
                 android:orientation="horizontal"
                 android:paddingStart="16dp"
-                android:paddingEnd="16dp">
+                android:paddingEnd="16dp"
+                android:layout_gravity="center">
 
                 <TextView
                     android:layout_width="wrap_content"
@@ -71,10 +72,10 @@
                 android:id="@+id/recyclerView_sync_errors"
                 android:layout_width="wrap_content"
                 android:layout_height="0dp"
-                android:layout_marginStart="32dp"
-                android:layout_marginTop="16dp"
-                android:layout_marginEnd="32dp"
-                android:layout_marginBottom="16dp"
+                android:layout_marginStart="@dimen/margin_16_32"
+                android:layout_marginTop="@dimen/margin_8_16"
+                android:layout_marginEnd="@dimen/margin_16_32"
+                android:layout_marginBottom="@dimen/margin_8_16"
                 android:layout_weight="1"
                 android:background="@drawable/white_with_stroke"
                 android:orientation="vertical"
@@ -89,30 +90,32 @@
             <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_gravity="end"
-                android:layout_marginStart="16dp"
-                android:layout_marginTop="32dp"
-                android:layout_marginEnd="16dp"
-                android:layout_marginBottom="16dp"
-                android:gravity="top|end"
+                android:layout_gravity="center"
+                android:layout_marginStart="@dimen/margin_8_16"
+                android:layout_marginTop="@dimen/margin_16_32"
+                android:layout_marginEnd="@dimen/margin_8_16"
+                android:layout_marginBottom="@dimen/margin_8_16"
+                android:gravity="center_vertical"
                 android:orientation="horizontal">
 
                 <Button
                     android:id="@+id/btn_delete_all"
-                    android:layout_width="wrap_content"
+                    android:layout_width="0dp"
+                    android:layout_weight="1"
                     android:layout_height="wrap_content"
-                    android:layout_marginEnd="16dp"
+                    android:layout_marginEnd="@dimen/margin_4"
                     android:backgroundTint="@color/alertLight"
                     android:textAppearance="@style/ButtonTextStyling"
                     android:enabled="@{viewModel.loading ? false : true }"
-                    android:text="@string/sync_error_btn_delete_all"
+                    android:text="@string/sync_error_btn_delete_all_mobile"
                     android:visibility="@{viewModel.showDeleteAllSyncErrorsButton ? View.VISIBLE : View.GONE }" />
 
                 <Button
                     android:id="@+id/btn_share"
-                    android:layout_width="wrap_content"
+                    android:layout_width="0dp"
+                    android:layout_weight="1"
                     android:layout_height="wrap_content"
-                    android:layout_marginEnd="16dp"
+                    android:layout_marginEnd="@dimen/margin_4"
                     android:enabled="@{viewModel.loading ? false : true }"
                     android:text="@string/sync_error_btn_share"
                     android:backgroundTint="@color/colorPrimary"
@@ -121,7 +124,8 @@
 
                 <Button
                     android:id="@+id/btn_finish"
-                    android:layout_width="wrap_content"
+                    android:layout_width="0dp"
+                    android:layout_weight="1"
                     android:layout_height="wrap_content"
                     android:backgroundTint="@color/colorPrimary"
                     android:textAppearance="@style/ButtonTextStyling"
@@ -129,6 +133,5 @@
             </LinearLayout>
         </LinearLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
-
 
 </layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -306,6 +306,7 @@
     <string name="setup_btn_enable">Enable</string>
     <string name="sync_error_btn_share">Share</string>
     <string name="sync_error_btn_delete_all">Delete All</string>
+    <string name="sync_error_btn_delete_all_mobile">Delete</string>
     <string name="sync_error_dialog_title">Sync Errors</string>
     <string name="sync_error_dialog_share_failure">Error building sync errors file to share</string>
     <string name="sync_error_dialog_last_sync_date_label">Last Sync Date: </string>


### PR DESCRIPTION
# This PR focuses on;

1. Making a new file for the landscape orientation pop up  `layout-sw600dp/dialog_sync_error.xml`
2. Adjusting the `layout/dialog_sync_error.xml` file to work for **both tablet and mobile portrait**
3. Creating a `new string for the delete button on the mobile` version