### PR TITLE
Dismiss pop up by pressing buttons

### DIFF
--- a/app/src/main/java/com/jnj/vaccinetracker/register/dialogs/QrCodeGeneratorDialog.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/register/dialogs/QrCodeGeneratorDialog.kt
@@ -21,6 +21,8 @@ class QrCodeGeneratorDialog(
         val dialog = Dialog(requireContext())
         dialog.setContentView(R.layout.dialog_qr_code_generator)
 
+        isCancelable = false
+
         initializeViews(dialog)
         generateQrCode()
 

--- a/app/src/main/java/com/jnj/vaccinetracker/visit/screens/ContraindicationsFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visit/screens/ContraindicationsFragment.kt
@@ -123,6 +123,7 @@ class ContraindicationsFragment : BaseFragment() {
             true,
             R.string.visit_dosing_warning_out_of_time_window_description
         )
+        dialog.isCancelable = false
         dialog.show(requireActivity().supportFragmentManager, VisitActivity.TAG_DIALOG_DOSING_OUT_OF_WINDOW)
     }
 
@@ -131,6 +132,7 @@ class ContraindicationsFragment : BaseFragment() {
            false,
            R.string.visit_dosing_warning_far_from_time_window_description
        )
+       dialog.isCancelable = false
        dialog.show(requireActivity().supportFragmentManager, "TAG_DOSING_OUT_OF_WINDOW")
    }
 }


### PR DESCRIPTION
# This PR focuses on;

1. Making the generated QR code pop up to be dismissed only by pressing the close button
2. Making the dosing out of window pop up to be dismissed by pressing either cancel or confirm (with 5 days range) buttons