### PR TITLE
Removing duplicated mobile mother's column title name

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,7 +95,6 @@
     <string name="participant_matching_title">Child matching</string>
     <string name="visits_overview_client_mothers_name_column_label">Mother\'s Name</string>
     <string name="eye_title" translatable="false">e</string>
-    <string name="visits_overview_client_mothers_name_column_label_mobile" translatable="false">Mother</string>
     <string name="participant_flow_child_number_title">Child Number</string>
     <string name="participant_flow_participant_id_title">Child ID</string>
     <string name="participant_flow_participant_id_hint">Scan Child ID QR Code</string>


### PR DESCRIPTION
# This PR focuses on;

1. Removing a duplicated string of the mobile mother's column title name