### PR TITLE
Dismiss confirm visit location popup using buttons only

### DIFF
--- a/app/src/main/java/com/jnj/vaccinetracker/login/LoginActivity.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/login/LoginActivity.kt
@@ -187,7 +187,7 @@ class LoginActivity : BaseActivity() {
             getString(R.string.confirm_visit_place_message, visitPlace)
         }
 
-        AlertDialog.Builder(this)
+        val dialog = AlertDialog.Builder(this)
             .setTitle(R.string.confirm_visit_place_title)
             .setMessage(message)
             .setPositiveButton(R.string.confirm) { _, _ ->
@@ -196,7 +196,11 @@ class LoginActivity : BaseActivity() {
                 viewModel.login(username, password, visitPlace)
             }
             .setNegativeButton(R.string.cancel, null)
-            .show()
+            .setCancelable(false)
+            .create()
+
+        dialog.setCanceledOnTouchOutside(false)
+        dialog.show()
     }
 
     @RequiresApi(Build.VERSION_CODES.O)


### PR DESCRIPTION
# This PR focuses on;

1. Ensuring that the confirm location pop up on login page is dismissed by either pressing cancel or confirm not outside the pop up