### PR TITLE
Screen orientation fix for visit overview screen

### DIFF
--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/activity/VisitsOverviewFlowActivity.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/activity/VisitsOverviewFlowActivity.kt
@@ -38,8 +38,14 @@ class VisitsOverviewFlowActivity : BaseActivity() {
         binding = DataBindingUtil.setContentView(this, R.layout.activity_visit_overview_flow)
         binding.lifecycleOwner = this
 
-        visitsOverviewViewModel.currentScreen.observe(this) { screen ->
-            navigateToScreen(screen, visitsOverviewViewModel.navigationDirection)
+        if (savedInstanceState == null) {
+            visitsOverviewViewModel.currentScreen.observe(this) { screen ->
+                navigateToScreen(screen, visitsOverviewViewModel.navigationDirection)
+            }
+        } else {
+            visitsOverviewViewModel.currentScreen.observe(this) { screen ->
+                screen?.let { title = getString(it.title) }
+            }
         }
     }
 

--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/screens/VisitsListFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/screens/VisitsListFragment.kt
@@ -39,12 +39,21 @@ import java.util.Locale
 import javax.inject.Inject
 
 @RequiresApi(Build.VERSION_CODES.Q)
-class VisitsListFragment(private val visitsKey: String) : BaseFragment(),
+class VisitsListFragment : BaseFragment(),
     ReportOverviewDatePickerDialog.VisitsOverviewDatePickerListener {
 
     companion object {
         private const val START_DATE_PICKER_DIALOG_TAG = "startDatePicker"
         private const val END_DATE_PICKER_DIALOG_TAG = "endDatePicker"
+        private const val ARG_VISITS_KEY = "arg_visits_key"
+
+        fun newInstance(visitsKey: String): VisitsListFragment {
+            return VisitsListFragment().apply {
+                arguments = Bundle().apply {
+                    putString(ARG_VISITS_KEY, visitsKey)
+                }
+            }
+        }
     }
 
     private lateinit var binding: FragmentVisitsListBinding
@@ -52,9 +61,15 @@ class VisitsListFragment(private val visitsKey: String) : BaseFragment(),
     private val visitsListViewModel: VisitsListViewModel by viewModels { viewModelFactory }
     private var selectedStartDate: DateTime? = null
     private var selectedEndDate: DateTime? = null
+    private var visitsKey: String = Constants.VISITS_OVERVIEW_SCHEDULED_VISITS_KEY
 
     @Inject lateinit var configurationManager: ConfigurationManager
     @Inject lateinit var visitManager: VisitManager
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        arguments?.getString(ARG_VISITS_KEY)?.let { visitsKey = it }
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/screens/VisitsOverviewFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/screens/VisitsOverviewFragment.kt
@@ -47,7 +47,7 @@ class VisitsOverviewFragment : BaseFragment() {
 
     @RequiresApi(Build.VERSION_CODES.Q)
     private fun navigateToVisitsList(visitsKey: String) {
-        val fragment = VisitsListFragment(visitsKey)
+        val fragment = VisitsListFragment.newInstance(visitsKey)
         parentFragmentManager.beginTransaction()
             .replace(R.id.fragment_container, fragment)
             .addToBackStack(null)


### PR DESCRIPTION
# This PR focuses on;
 
- Fixing the screen orientation bug where when screen is rotated it rolls to the previous screen

### Screens fixed
1. missed visits overview
2. visit history overview
3. scheduled visits overview

### Verification
1. Tap any of the three buttons (Scheduled / Historical / Missed).
4. Rotate the device — the app remains on the selected visits list and retains the title/filters.


### Files changed
1. VisitsListFragment.kt
2. VisitsOverviewFragment.kt
5. VisitsOverviewFlowActivity.kt