### PR TITLE
Screen orientation fix for reports overview screens

### DIFF
--- a/app/src/main/java/com/jnj/vaccinetracker/reportsoverview/childrenoverview/activity/ReportsOverviewFlowActivity.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/reportsoverview/childrenoverview/activity/ReportsOverviewFlowActivity.kt
@@ -25,8 +25,11 @@ class ReportsOverviewFlowActivity : BaseActivity() {
     private val reportsOverviewViewModel: ReportsOverviewViewModel by viewModels { viewModelFactory }
     private lateinit var binding: ActivityReportsOverviewFlowBinding
 
+    private var isRestored = false
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        isRestored = savedInstanceState != null
         savedInstanceState?.let { reportsOverviewViewModel.restoreInstanceState(it) }
 
         binding = DataBindingUtil.setContentView(this, R.layout.activity_reports_overview_flow)
@@ -38,6 +41,8 @@ class ReportsOverviewFlowActivity : BaseActivity() {
     }
 
     private fun navigateToScreen(screen: ReportsOverviewViewModel.Screen?, navigationDirection: NavigationDirection) {
+        if (isRestored && supportFragmentManager.findFragmentById(R.id.fragment_container) != null) return
+
         val fragment = when (screen) {
             ReportsOverviewViewModel.Screen.REPORTS_OVERVIEW -> ReportsOverviewFragment()
             else -> null

--- a/app/src/main/java/com/jnj/vaccinetracker/reportsoverview/vaccinesoverview/activity/VaccinesOverviewFlowActivity.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/reportsoverview/vaccinesoverview/activity/VaccinesOverviewFlowActivity.kt
@@ -27,9 +27,12 @@ class VaccinesOverviewFlowActivity : BaseActivity() {
     private val vaccinesOverviewViewModel: VaccinesOverviewViewModel by viewModels { viewModelFactory }
     private lateinit var binding: ActivityVaccinesOverviewFlowBinding
 
+    private var isRestored = false
+
     @RequiresApi(Build.VERSION_CODES.Q)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        isRestored = savedInstanceState != null
         savedInstanceState?.let { vaccinesOverviewViewModel.restoreInstanceState(it) }
 
         binding = DataBindingUtil.setContentView(this, R.layout.activity_vaccines_overview_flow)
@@ -47,6 +50,8 @@ class VaccinesOverviewFlowActivity : BaseActivity() {
 
     @RequiresApi(Build.VERSION_CODES.Q)
     private fun navigateToScreen(screen: VaccinesOverviewViewModel.Screen?, navigationDirection: NavigationDirection) {
+        if (isRestored && supportFragmentManager.findFragmentById(R.id.fragment_container) != null) return
+
         val fragment = when (screen) {
             VaccinesOverviewViewModel.Screen.VACCINES_OVERVIEW -> VaccinesOverviewFragment()
             else -> null


### PR DESCRIPTION
# This PR focuses on;

- Fixing the screen orientation bug where when screen is rotated it rolls to the previous screen

### Screens fixed
1. Registered children overview
2. Vaccines overview

### Verification
1. Tap any of the two buttons (Registered children, vaccines).
2. Rotate the device — the app remains on the selected visits list and retains the title/filters.

### Files changed
1. ReportsOverviewFlowActivity.kt
2. VaccinesOverviewFlowActivity.kt