### PR TITLE
Persist filter dates and data during orientation of screen

### DIFF
--- a/app/src/main/java/com/jnj/vaccinetracker/reportsoverview/childrenoverview/screens/RegisteredParticipantsFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/reportsoverview/childrenoverview/screens/RegisteredParticipantsFragment.kt
@@ -9,7 +9,7 @@ import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.widget.addTextChangedListener
 import androidx.databinding.DataBindingUtil
-import androidx.fragment.app.viewModels
+import androidx.fragment.app.activityViewModels
 import com.jnj.vaccinetracker.R
 import com.jnj.vaccinetracker.common.data.models.Constants
 import com.jnj.vaccinetracker.common.dialogs.ReportOverviewDatePickerDialog
@@ -30,7 +30,6 @@ import org.apache.poi.hssf.usermodel.HSSFWorkbook
 import java.util.Locale
 import java.time.ZoneId
 
-
 @RequiresApi(Build.VERSION_CODES.Q)
 class RegisteredParticipantsFragment : BaseFragment(),
     ReportOverviewDatePickerDialog.VisitsOverviewDatePickerListener {
@@ -38,13 +37,36 @@ class RegisteredParticipantsFragment : BaseFragment(),
     companion object {
         private const val START_DATE_PICKER_DIALOG_TAG = "startDatePicker"
         private const val END_DATE_PICKER_DIALOG_TAG = "endDatePicker"
+        private const val STATE_START_DATE_MILLIS = "state_start_date_millis"
+        private const val STATE_END_DATE_MILLIS = "state_end_date_millis"
     }
 
     private lateinit var patientAdapter: PatientAdapter
     private lateinit var binding: FragmentRegisteredChildrenBinding
-    private val registeredParticipantsViewModel: RegisteredParticipantsViewModel by viewModels { viewModelFactory }
+    private val registeredParticipantsViewModel: RegisteredParticipantsViewModel by activityViewModels { viewModelFactory }
     private var selectedStartDate: DateTime? = null
     private var selectedEndDate: DateTime? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        savedInstanceState?.let { bundle ->
+            if (bundle.containsKey(STATE_START_DATE_MILLIS)) {
+                val startMillis = bundle.getLong(STATE_START_DATE_MILLIS)
+                selectedStartDate = DateTime(startMillis.toDouble())
+            }
+            if (bundle.containsKey(STATE_END_DATE_MILLIS)) {
+                val endMillis = bundle.getLong(STATE_END_DATE_MILLIS)
+                selectedEndDate = DateTime(endMillis.toDouble())
+            }
+        }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        selectedStartDate?.let { outState.putLong(STATE_START_DATE_MILLIS, it.toDate().time) }
+        selectedEndDate?.let { outState.putLong(STATE_END_DATE_MILLIS, it.toDate().time) }
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -56,10 +78,18 @@ class RegisteredParticipantsFragment : BaseFragment(),
         binding.lifecycleOwner = viewLifecycleOwner
 
         setupRecyclerView()
-        loadPatients()
         setupObservers()
         setupFilterButtons()
         setupDownloadButtons()
+
+        if (selectedStartDate != null) binding.labelStartDate.text = formatDate(selectedStartDate)
+        if (selectedEndDate != null) binding.labelEndDate.text = formatDate(selectedEndDate)
+
+        if (savedInstanceState == null) {
+            loadPatients()
+        } else {
+            registeredParticipantsViewModel.patientDTOs.value?.let { applyFilters(it) }
+        }
 
         return binding.root
     }

--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/screens/VisitsListFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/screens/VisitsListFragment.kt
@@ -46,6 +46,8 @@ class VisitsListFragment : BaseFragment(),
         private const val START_DATE_PICKER_DIALOG_TAG = "startDatePicker"
         private const val END_DATE_PICKER_DIALOG_TAG = "endDatePicker"
         private const val ARG_VISITS_KEY = "arg_visits_key"
+        private const val STATE_START_DATE_MILLIS = "state_start_date_millis"
+        private const val STATE_END_DATE_MILLIS = "state_end_date_millis"
 
         fun newInstance(visitsKey: String): VisitsListFragment {
             return VisitsListFragment().apply {
@@ -69,6 +71,23 @@ class VisitsListFragment : BaseFragment(),
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         arguments?.getString(ARG_VISITS_KEY)?.let { visitsKey = it }
+
+        savedInstanceState?.let { bundle ->
+            if (bundle.containsKey(STATE_START_DATE_MILLIS)) {
+                val startMillis = bundle.getLong(STATE_START_DATE_MILLIS)
+                selectedStartDate = DateTime(startMillis.toDouble())
+            }
+            if (bundle.containsKey(STATE_END_DATE_MILLIS)) {
+                val endMillis = bundle.getLong(STATE_END_DATE_MILLIS)
+                selectedEndDate = DateTime(endMillis.toDouble())
+            }
+        }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        selectedStartDate?.let { outState.putLong(STATE_START_DATE_MILLIS, it.toDate().time) }
+        selectedEndDate?.let { outState.putLong(STATE_END_DATE_MILLIS, it.toDate().time) }
     }
 
     override fun onCreateView(
@@ -79,11 +98,22 @@ class VisitsListFragment : BaseFragment(),
         setHasOptionsMenu(true)
         binding = DataBindingUtil.inflate(inflater, R.layout.fragment_visits_list, container, false)
         setupRecyclerView()
-        loadVisitsData()
         setupObservers()
         setupFilterButtons()
         setupDownloadButtons()
 
+        if (selectedStartDate != null) {
+            binding.labelStartDate.text = formatDate(selectedStartDate)
+        }
+        if (selectedEndDate != null) {
+            binding.labelEndDate.text = formatDate(selectedEndDate)
+        }
+
+        if (savedInstanceState == null) {
+            loadVisitsData()
+        } else {
+            visitsListViewModel.visitDTOs.value?.let { applyFilters(it) }
+        }
         return binding.root
     }
 
@@ -145,8 +175,8 @@ class VisitsListFragment : BaseFragment(),
     }
 
     private fun setDateLabelsAndLoadData(loadData: () -> Unit) {
-        selectedStartDate = DateTime.now()
-        selectedEndDate = DateTime.now()
+        if (selectedStartDate == null) selectedStartDate = DateTime.now()
+        if (selectedEndDate == null) selectedEndDate = DateTime.now()
         binding.labelStartDate.text = formatDate(selectedStartDate)
         binding.labelEndDate.text = formatDate(selectedEndDate)
         loadData()


### PR DESCRIPTION
# This PR focuses on;

* The UX of both RegisteredParticipantsFragment and VisitsListFragment by ensuring that date filters and data are preserved during screen rotations. 

* It prevents unnecessary data reloads and keeps the filter state consistent for the user.