### PR TITLE
Fix date filtering to use full-day ranges

### DIFF
--- a/app/src/main/java/com/jnj/vaccinetracker/reportsoverview/vaccinesoverview/screens/VaccinesOverviewFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/reportsoverview/vaccinesoverview/screens/VaccinesOverviewFragment.kt
@@ -169,8 +169,9 @@ class VaccinesOverviewFragment : BaseFragment(),
     }
 
     private fun initializeDefaultDates() {
-        val today = DateTime.now()
-        val firstDayOfMonth = today.startOfMonth
+        val now = DateTime.now()
+        val today = DateTime(now.yearInt, now.month1, now.dayOfMonth)
+        val firstDayOfMonth = DateTime(now.yearInt, now.month1, 1)
 
         selectedStartDate = firstDayOfMonth
         selectedEndDate = today

--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/screens/VisitsListFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/screens/VisitsListFragment.kt
@@ -153,8 +153,8 @@ class VisitsListFragment : BaseFragment(),
                 setDateLabelsAndLoadData { visitsListViewModel.getHistoricalVisitsData() }
             }
             Constants.VISITS_OVERVIEW_MISSED_VISITS_KEY -> {
-                val now = DateTime.now()
-                val yesterday = DateTime(now.yearInt, now.month1, now.dayOfMonth - 1)
+                val yesterdayDateTime = DateTime.now() - 1.days
+                val yesterday = DateTime(yesterdayDateTime.yearInt, yesterdayDateTime.month1, yesterdayDateTime.dayOfMonth)
                 selectedStartDate = yesterday
                 selectedEndDate = yesterday
                 binding.labelStartDate.text = formatDate(selectedStartDate)

--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/screens/VisitsListFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/screens/VisitsListFragment.kt
@@ -153,8 +153,10 @@ class VisitsListFragment : BaseFragment(),
                 setDateLabelsAndLoadData { visitsListViewModel.getHistoricalVisitsData() }
             }
             Constants.VISITS_OVERVIEW_MISSED_VISITS_KEY -> {
-                selectedStartDate = DateTime.now() - 1.days
-                selectedEndDate = DateTime.now() - 1.days
+                val now = DateTime.now()
+                val yesterday = DateTime(now.yearInt, now.month1, now.dayOfMonth - 1)
+                selectedStartDate = yesterday
+                selectedEndDate = yesterday
                 binding.labelStartDate.text = formatDate(selectedStartDate)
                 binding.labelEndDate.text = formatDate(selectedEndDate)
                 visitsListViewModel.getMissedVisitsData()
@@ -175,8 +177,14 @@ class VisitsListFragment : BaseFragment(),
     }
 
     private fun setDateLabelsAndLoadData(loadData: () -> Unit) {
-        if (selectedStartDate == null) selectedStartDate = DateTime.now()
-        if (selectedEndDate == null) selectedEndDate = DateTime.now()
+        if (selectedStartDate == null) {
+            val now = DateTime.now()
+            selectedStartDate = DateTime(now.yearInt, now.month1, now.dayOfMonth)
+        }
+        if (selectedEndDate == null) {
+            val now = DateTime.now()
+            selectedEndDate = DateTime(now.yearInt, now.month1, now.dayOfMonth)
+        }
         binding.labelStartDate.text = formatDate(selectedStartDate)
         binding.labelEndDate.text = formatDate(selectedEndDate)
         loadData()


### PR DESCRIPTION
# Fix date filtering to use full-day ranges

* Normalize all selected dates to start of day (00:00:00) to ensure full-day coverage
* Replace direct use of DateTime.now() with explicit date construction (year, month, day)
* Fix “yesterday” calculation using Klock-safe subtraction to handle month boundaries correctly
* Improves accuracy of scheduled, historical, and missed visit reports
