### PR TITLE
fix: exclude outreach name from non-outreach visits

### DIFF
--- a/app/src/main/java/com/jnj/vaccinetracker/login/LoginActivity.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/login/LoginActivity.kt
@@ -170,9 +170,13 @@ class LoginActivity : BaseActivity() {
         val username = binding.editUsername.text.toString()
         val password = binding.editPassword.text.toString()
         val visitPlace = binding.dropdownLoginVisitPlace.text.toString()
-        val outreachName = binding.editOutreachName.text.toString().uppercase()
+        val outreachName = if (selectedVisitPlace == Constants.VISIT_PLACE_OUTREACH) {
+            binding.editOutreachName.text.toString().uppercase()
+        } else {
+            null
+        }
 
-        if ((selectedVisitPlace == Constants.VISIT_PLACE_OUTREACH) && (outreachName.isEmpty())) {
+        if ((selectedVisitPlace == Constants.VISIT_PLACE_OUTREACH) && (outreachName.isNullOrEmpty())) {
             binding.editOutreachName.error = resourcesWrapper.getString(R.string.login_label_validation_no_outreach_name)
             return
         } else {
@@ -180,9 +184,9 @@ class LoginActivity : BaseActivity() {
         }
     }
 
-    private fun showConfirmVisitPlaceDialog(username: String, password: String, visitPlace: String, outreachName: String) {
+    private fun showConfirmVisitPlaceDialog(username: String, password: String, visitPlace: String, outreachName: String?) {
         val message = if (selectedVisitPlace == Constants.VISIT_PLACE_OUTREACH) {
-            getString(R.string.confirm_visit_place_message_with_outreach, visitPlace, outreachName)
+            getString(R.string.confirm_visit_place_message_with_outreach, visitPlace, outreachName ?: "")
         } else {
             getString(R.string.confirm_visit_place_message, visitPlace)
         }
@@ -191,8 +195,12 @@ class LoginActivity : BaseActivity() {
             .setTitle(R.string.confirm_visit_place_title)
             .setMessage(message)
             .setPositiveButton(R.string.confirm) { _, _ ->
-                val defaultOutreachName = outreachName.ifEmpty { "No Outreach" }
-                saveVisitPlaceToMemory(visitPlace, defaultOutreachName)
+                val finalOutreachName = if (selectedVisitPlace == Constants.VISIT_PLACE_OUTREACH) {
+                    outreachName?.ifEmpty { "No Outreach" }
+                } else {
+                    null
+                }
+                saveVisitPlaceToMemory(visitPlace, finalOutreachName)
                 viewModel.login(username, password, visitPlace)
             }
             .setNegativeButton(R.string.cancel, null)
@@ -209,11 +217,15 @@ class LoginActivity : BaseActivity() {
         finish()
     }
 
-    private fun saveVisitPlaceToMemory(visitPlace: String, outreachName: String) {
+    private fun saveVisitPlaceToMemory(visitPlace: String, outreachName: String?) {
         val sharedPreferences = getSharedPreferences(Constants.USER_PREFERENCES_FILE_NAME, MODE_PRIVATE)
         val editor = sharedPreferences.edit()
         editor.putString(Constants.VISIT_PLACE_FILE_KEY, visitPlace)
-        editor.putString(Constants.OUTREACH_NAME, outreachName)
+        if (!outreachName.isNullOrEmpty()) {
+            editor.putString(Constants.OUTREACH_NAME, outreachName)
+        } else {
+            editor.remove(Constants.OUTREACH_NAME)
+        }
         editor.apply()
     }
 }

--- a/app/src/main/java/com/jnj/vaccinetracker/login/LoginActivity.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/login/LoginActivity.kt
@@ -38,6 +38,7 @@ class LoginActivity : BaseActivity() {
     companion object {
         private const val TAG_SETTINGS_DIALOG = "SettingsDialog"
         private const val TAG_UPDATE_DIALOG = "UpdateDialog"
+        private const val KEY_SELECTED_VISIT_PLACE = "selectedVisitPlace"
 
         fun create(context: Context): Intent {
             return Intent(context, LoginActivity::class.java)
@@ -60,6 +61,10 @@ class LoginActivity : BaseActivity() {
         binding.lifecycleOwner = this
         binding.viewModel = viewModel
         viewModel.init(true)
+
+        if (savedInstanceState != null) {
+            selectedVisitPlace = savedInstanceState.getString(KEY_SELECTED_VISIT_PLACE)
+        }
 
         binding.btnLogin.setOnClickListener { login() }
         binding.editPassword.setOnEditorActionListener { _, actionId, _ ->
@@ -113,9 +118,27 @@ class LoginActivity : BaseActivity() {
             }
         }
 
+        // Restore UI state after rotation
+        if (selectedVisitPlace != null) {
+            val index = visitPlaces.indexOf(selectedVisitPlace)
+            if (index >= 0) {
+                binding.dropdownLoginVisitPlace.setText(visitPlaces[index], false)
+                if (selectedVisitPlace == Constants.VISIT_PLACE_OUTREACH) {
+                    textInputOutreachName.visibility = View.VISIBLE
+                    visitPlaceIcon.visibility = View.VISIBLE
+                    binding.root.setBackgroundColor(getColor(R.color.outreach_bg_color))
+                }
+            }
+        }
+
         binding.root.setOnClickListener { hideKeyboard() }
         binding.btnUpdate.setOnClickListener { showUpdateDialog() }
         observeViewModel(this)
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putString(KEY_SELECTED_VISIT_PLACE, selectedVisitPlace)
     }
 
     override val syncBanner: SyncBanner
@@ -170,13 +193,13 @@ class LoginActivity : BaseActivity() {
         val username = binding.editUsername.text.toString()
         val password = binding.editPassword.text.toString()
         val visitPlace = binding.dropdownLoginVisitPlace.text.toString()
-        val outreachName = if (selectedVisitPlace == Constants.VISIT_PLACE_OUTREACH) {
-            binding.editOutreachName.text.toString().uppercase()
+        val outreachName = if (visitPlace == Constants.VISIT_PLACE_OUTREACH) {
+            binding.editOutreachName.text.toString().trim().uppercase()
         } else {
             null
         }
 
-        if ((selectedVisitPlace == Constants.VISIT_PLACE_OUTREACH) && (outreachName.isNullOrEmpty())) {
+        if ((visitPlace == Constants.VISIT_PLACE_OUTREACH) && (outreachName.isNullOrBlank())) {
             binding.editOutreachName.error = resourcesWrapper.getString(R.string.login_label_validation_no_outreach_name)
             return
         } else {
@@ -185,7 +208,7 @@ class LoginActivity : BaseActivity() {
     }
 
     private fun showConfirmVisitPlaceDialog(username: String, password: String, visitPlace: String, outreachName: String?) {
-        val message = if (selectedVisitPlace == Constants.VISIT_PLACE_OUTREACH) {
+        val message = if (visitPlace == Constants.VISIT_PLACE_OUTREACH) {
             getString(R.string.confirm_visit_place_message_with_outreach, visitPlace, outreachName ?: "")
         } else {
             getString(R.string.confirm_visit_place_message, visitPlace)

--- a/app/src/main/java/com/jnj/vaccinetracker/login/LoginActivity.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/login/LoginActivity.kt
@@ -195,12 +195,7 @@ class LoginActivity : BaseActivity() {
             .setTitle(R.string.confirm_visit_place_title)
             .setMessage(message)
             .setPositiveButton(R.string.confirm) { _, _ ->
-                val finalOutreachName = if (selectedVisitPlace == Constants.VISIT_PLACE_OUTREACH) {
-                    outreachName?.ifEmpty { "No Outreach" }
-                } else {
-                    null
-                }
-                saveVisitPlaceToMemory(visitPlace, finalOutreachName)
+                saveVisitPlaceToMemory(visitPlace, outreachName)
                 viewModel.login(username, password, visitPlace)
             }
             .setNegativeButton(R.string.cancel, null)

--- a/app/src/main/java/com/jnj/vaccinetracker/visit/VisitActivity.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visit/VisitActivity.kt
@@ -334,11 +334,14 @@ class VisitActivity :
                 Constants.VISIT_PLACE_FILE_KEY,
                 Constants.VISIT_PLACE_STATIC
             )
-        val outreachName =
+        val outreachName = if (visitPlace == Constants.VISIT_PLACE_OUTREACH) {
             getSharedPreferences(Constants.USER_PREFERENCES_FILE_NAME, MODE_PRIVATE).getString(
                 Constants.OUTREACH_NAME,
-                Constants.VISIT_PLACE_OUTREACH
+                null
             )
+        } else {
+            null
+        }
         viewModel.submitDosingVisit(missingSubstanceVisitDate, visitPlace, referralObservations, outreachName)
     }
 

--- a/app/src/main/java/com/jnj/vaccinetracker/visit/VisitActivity.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visit/VisitActivity.kt
@@ -329,13 +329,13 @@ class VisitActivity :
 
     override fun onReferralAfterVisitPageFinish(referralObservations: Map<String, String>) {
         val missingSubstanceVisitDate = viewModel.missingSubstancesVisitDate.value
-        val visitPlace =
-            getSharedPreferences(Constants.USER_PREFERENCES_FILE_NAME, MODE_PRIVATE).getString(
-                Constants.VISIT_PLACE_FILE_KEY,
-                Constants.VISIT_PLACE_STATIC
-            )
+        val sharedPreferences = getSharedPreferences(Constants.USER_PREFERENCES_FILE_NAME, MODE_PRIVATE)
+        val visitPlace = sharedPreferences.getString(
+            Constants.VISIT_PLACE_FILE_KEY,
+            Constants.VISIT_PLACE_STATIC
+        )
         val outreachName = if (visitPlace == Constants.VISIT_PLACE_OUTREACH) {
-            getSharedPreferences(Constants.USER_PREFERENCES_FILE_NAME, MODE_PRIVATE).getString(
+            sharedPreferences.getString(
                 Constants.OUTREACH_NAME,
                 null
             )


### PR DESCRIPTION
# Completely ignore outreach name for non-outreach visits

- Pass null instead of empty string for outreach name when visit place is STATIC or SCHOOL
- Update LoginActivity to conditionally collect and save outreach name
- Update VisitActivity to only retrieve outreach name for OUTREACH visits
- Utilize listOfNotNull in buildVisitAttributes to exclude null values from visit attributes
- Remove outreach name from SharedPreferences when visit place is not OUTREACH

This prevents weird/incorrect data from being saved to the database for non-outreach visits
by completely excluding the outreach name attribute instead of populating it with empty values.

Files changed:
- LoginActivity.kt (login, showConfirmVisitPlaceDialog, saveVisitPlaceToMemory)
- VisitActivity.kt (onReferralAfterVisitPageFinish)