### PR TITLE
Bug fix

### DIFF
--- a/app/src/main/java/com/jnj/vaccinetracker/common/domain/entities/BirthDate.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/common/domain/entities/BirthDate.kt
@@ -10,9 +10,6 @@ data class BirthDate(val time: Long) {
     val day: Int
 
     init {
-        // Use device local timezone so that dates returned from OpenMRS (which stores dates in
-        // the facility's local timezone) are interpreted correctly. klock DateTime(time) is UTC-only
-        // and would shift the day back by the UTC offset (e.g. UTC+3 causes -1 day).
         val cal = Calendar.getInstance()
         cal.timeInMillis = time
         year = cal.get(Calendar.YEAR)

--- a/app/src/main/java/com/jnj/vaccinetracker/common/domain/entities/BirthDate.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/common/domain/entities/BirthDate.kt
@@ -2,6 +2,7 @@ package com.jnj.vaccinetracker.common.domain.entities
 
 import com.soywiz.klock.DateFormat
 import com.soywiz.klock.DateTime
+import java.util.Calendar
 
 data class BirthDate(val time: Long) {
     val year: Int
@@ -9,10 +10,14 @@ data class BirthDate(val time: Long) {
     val day: Int
 
     init {
-        val birthDateTime = DateTime(time)
-        year = birthDateTime.yearInt
-        month = birthDateTime.month.index1
-        day = birthDateTime.dayOfMonth
+        // Use device local timezone so that dates returned from OpenMRS (which stores dates in
+        // the facility's local timezone) are interpreted correctly. klock DateTime(time) is UTC-only
+        // and would shift the day back by the UTC offset (e.g. UTC+3 causes -1 day).
+        val cal = Calendar.getInstance()
+        cal.timeInMillis = time
+        year = cal.get(Calendar.YEAR)
+        month = cal.get(Calendar.MONTH) + 1
+        day = cal.get(Calendar.DAY_OF_MONTH)
     }
 
     fun toDateTime(): DateTime {

--- a/app/src/main/java/com/jnj/vaccinetracker/common/exceptions/exceptions.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/common/exceptions/exceptions.kt
@@ -155,7 +155,7 @@ class EncryptionException(override val message: String, override val cause: Thro
 
 
 class TotalSyncScopeRecordCountMismatchException(
-    override val message: String, val backendTableCount: Long,
+    override val message: String, val backendTableCount: Long, val localCount: Long,
 ) : AppException()
 
 class ReportSyncCompletedDateException(override val message: String, override val cause: Throwable? = null) : AppException()

--- a/app/src/main/java/com/jnj/vaccinetracker/common/util/SubstancesDataUtil.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/common/util/SubstancesDataUtil.kt
@@ -455,8 +455,6 @@ class SubstancesDataUtil {
         }
 
         private fun isAnySubstanceApplied(visits: List<VisitDetail>): Boolean {
-            // Treat any OCCURRED dosing visit as evidence of prior vaccination, even when
-            // vaccine observations are absent (e.g. past visits entered without specific dates).
             return visits.any { visit ->
                 visit.visitStatus == Constants.VISIT_STATUS_OCCURRED ||
                 visit.observations.keys.any { key -> key.endsWith(Constants.VXNAID_DATE_SUFFIX) }

--- a/app/src/main/java/com/jnj/vaccinetracker/common/util/SubstancesDataUtil.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/common/util/SubstancesDataUtil.kt
@@ -455,10 +455,11 @@ class SubstancesDataUtil {
         }
 
         private fun isAnySubstanceApplied(visits: List<VisitDetail>): Boolean {
+            // Treat any OCCURRED dosing visit as evidence of prior vaccination, even when
+            // vaccine observations are absent (e.g. past visits entered without specific dates).
             return visits.any { visit ->
-                visit.observations.keys.any { key ->
-                    key.endsWith(Constants.VXNAID_DATE_SUFFIX)
-                }
+                visit.visitStatus == Constants.VISIT_STATUS_OCCURRED ||
+                visit.observations.keys.any { key -> key.endsWith(Constants.VXNAID_DATE_SUFFIX) }
             }
         }
 

--- a/app/src/main/java/com/jnj/vaccinetracker/reportsoverview/hmis105/screens/Hmis105ChildHealthFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/reportsoverview/hmis105/screens/Hmis105ChildHealthFragment.kt
@@ -32,6 +32,7 @@ import com.jnj.vaccinetracker.reportsoverview.hmis105.model.Hmis105ChildHealthVi
 import com.soywiz.klock.DateTime
 import com.soywiz.klock.DateFormat
 import com.soywiz.klock.jvm.toDate
+import java.util.Calendar
 import org.apache.poi.hssf.usermodel.HSSFWorkbook
 
 @RequiresApi(Build.VERSION_CODES.Q)
@@ -137,9 +138,12 @@ class Hmis105ChildHealthFragment : BaseFragment(),
     }
 
     private fun initializeDefaultDates() {
-        val today = DateTime.now()
-        viewModel.selectedStartDate.value = DateTime(today.yearInt, today.month, 1)
-        viewModel.selectedEndDate.value   = DateTime(today.yearInt, today.month1, today.dayOfMonth)
+        // Use Calendar.getInstance() (local timezone) so "today" reflects the device's local date,
+        // not UTC — devices in UTC+3 would otherwise see yesterday's date as "today" between midnight-3AM.
+        val c = Calendar.getInstance()
+        val today = DateTime(c.get(Calendar.YEAR), c.get(Calendar.MONTH) + 1, c.get(Calendar.DAY_OF_MONTH))
+        viewModel.selectedStartDate.value = DateTime(today.yearInt, today.month1, 1)
+        viewModel.selectedEndDate.value   = today
         updateDateLabels()
     }
 

--- a/app/src/main/java/com/jnj/vaccinetracker/reportsoverview/hmis105/screens/Hmis105ChildHealthFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/reportsoverview/hmis105/screens/Hmis105ChildHealthFragment.kt
@@ -138,8 +138,6 @@ class Hmis105ChildHealthFragment : BaseFragment(),
     }
 
     private fun initializeDefaultDates() {
-        // Use Calendar.getInstance() (local timezone) so "today" reflects the device's local date,
-        // not UTC — devices in UTC+3 would otherwise see yesterday's date as "today" between midnight-3AM.
         val c = Calendar.getInstance()
         val today = DateTime(c.get(Calendar.YEAR), c.get(Calendar.MONTH) + 1, c.get(Calendar.DAY_OF_MONTH))
         viewModel.selectedStartDate.value = DateTime(today.yearInt, today.month1, 1)

--- a/app/src/main/java/com/jnj/vaccinetracker/reportsoverview/hmis105/screens/Hmis105ReportFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/reportsoverview/hmis105/screens/Hmis105ReportFragment.kt
@@ -29,6 +29,7 @@ import com.jnj.vaccinetracker.reportsoverview.hmis105.model.Hmis105ViewModel
 import com.soywiz.klock.DateTime
 import com.soywiz.klock.DateFormat
 import com.soywiz.klock.jvm.toDate
+import java.util.Calendar
 import org.apache.poi.hssf.usermodel.HSSFWorkbook
 
 @RequiresApi(Build.VERSION_CODES.Q)
@@ -152,8 +153,11 @@ class Hmis105ReportFragment : BaseFragment(),
     }
 
      private fun initializeDefaultDates() {
-         val today = DateTime.now()
-         val monthStart = DateTime(today.yearInt, today.month, 1)
+         // Use Calendar.getInstance() (local timezone) so "today" reflects the device's local date,
+         // not UTC — devices in UTC+3 would otherwise see yesterday's date as "today" between midnight-3AM.
+         val c = Calendar.getInstance()
+         val today = DateTime(c.get(Calendar.YEAR), c.get(Calendar.MONTH) + 1, c.get(Calendar.DAY_OF_MONTH))
+         val monthStart = DateTime(today.yearInt, today.month1, 1)
          viewModel.selectedStartDate.value = monthStart
          viewModel.selectedEndDate.value = today
          updateDateLabels()

--- a/app/src/main/java/com/jnj/vaccinetracker/reportsoverview/hmis105/screens/Hmis105ReportFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/reportsoverview/hmis105/screens/Hmis105ReportFragment.kt
@@ -153,8 +153,6 @@ class Hmis105ReportFragment : BaseFragment(),
     }
 
      private fun initializeDefaultDates() {
-         // Use Calendar.getInstance() (local timezone) so "today" reflects the device's local date,
-         // not UTC — devices in UTC+3 would otherwise see yesterday's date as "today" between midnight-3AM.
          val c = Calendar.getInstance()
          val today = DateTime(c.get(Calendar.YEAR), c.get(Calendar.MONTH) + 1, c.get(Calendar.DAY_OF_MONTH))
          val monthStart = DateTime(today.yearInt, today.month1, 1)

--- a/app/src/main/java/com/jnj/vaccinetracker/reportsoverview/vaccinesoverview/screens/VaccinesOverviewFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/reportsoverview/vaccinesoverview/screens/VaccinesOverviewFragment.kt
@@ -174,8 +174,6 @@ class VaccinesOverviewFragment : BaseFragment(),
     }
 
     private fun initializeDefaultDates() {
-        // Use Calendar.getInstance() (local timezone) so that "today" reflects the device's local date,
-        // not UTC — devices in UTC+3 would otherwise see yesterday's date as "today" between midnight-3AM.
         val c = Calendar.getInstance()
         val today = DateTime(c.get(Calendar.YEAR), c.get(Calendar.MONTH) + 1, c.get(Calendar.DAY_OF_MONTH))
         val firstDayOfMonth = DateTime(today.yearInt, today.month1, 1)

--- a/app/src/main/java/com/jnj/vaccinetracker/reportsoverview/vaccinesoverview/screens/VaccinesOverviewFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/reportsoverview/vaccinesoverview/screens/VaccinesOverviewFragment.kt
@@ -39,6 +39,7 @@ import com.soywiz.klock.DateFormat
 import com.soywiz.klock.DateTime
 import com.soywiz.klock.jvm.toDate
 import kotlinx.coroutines.launch
+import java.util.Calendar
 import org.apache.poi.hssf.usermodel.HSSFWorkbook
 import org.apache.poi.ss.util.CellRangeAddress
 import javax.inject.Inject
@@ -173,9 +174,11 @@ class VaccinesOverviewFragment : BaseFragment(),
     }
 
     private fun initializeDefaultDates() {
-        val now = DateTime.now()
-        val today = DateTime(now.yearInt, now.month1, now.dayOfMonth)
-        val firstDayOfMonth = DateTime(now.yearInt, now.month1, 1)
+        // Use Calendar.getInstance() (local timezone) so that "today" reflects the device's local date,
+        // not UTC — devices in UTC+3 would otherwise see yesterday's date as "today" between midnight-3AM.
+        val c = Calendar.getInstance()
+        val today = DateTime(c.get(Calendar.YEAR), c.get(Calendar.MONTH) + 1, c.get(Calendar.DAY_OF_MONTH))
+        val firstDayOfMonth = DateTime(today.yearInt, today.month1, 1)
 
         selectedStartDate = firstDayOfMonth
         selectedEndDate = today

--- a/app/src/main/java/com/jnj/vaccinetracker/sync/domain/usecases/ValidateSyncResponseUseCase.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/sync/domain/usecases/ValidateSyncResponseUseCase.kt
@@ -32,14 +32,16 @@ class ValidateSyncResponseUseCase @Inject constructor(
             val count = draftCount + syncEntityCount
             if (count != totalSyncScopeRecordCount) {
                 throw TotalSyncScopeRecordCountMismatchException(message = """local sync record count is $syncEntityCount including $draftCount uploaded drafts, $deletedCount voided, $failedCount failed.
-                    |But backend totalSyncScopeRecordCount is $totalSyncScopeRecordCount 
+                    |But backend totalSyncScopeRecordCount is $totalSyncScopeRecordCount
                     |of which $ignoredCount are expected to be uploaded drafts
-                    |and $voidedCount are expected to be voided""".trimMargin(), totalSyncScopeRecordCount)
+                    |and $voidedCount are expected to be voided""".trimMargin(),
+                    backendTableCount = totalSyncScopeRecordCount, localCount = syncEntityCount)
             }
         } else if (syncEntityCount != totalSyncScopeRecordCount) {
             throw TotalSyncScopeRecordCountMismatchException(message = """local sync record count is $syncEntityCount including $deletedCount voided, $failedCount failed
                 |but backend totalSyncScopeRecordCount is $totalSyncScopeRecordCount
-                |of which $voidedCount are expected to be voided""".trimMargin(), totalSyncScopeRecordCount)
+                |of which $voidedCount are expected to be voided""".trimMargin(),
+                backendTableCount = totalSyncScopeRecordCount, localCount = syncEntityCount)
         }
     }
 

--- a/app/src/main/java/com/jnj/vaccinetracker/sync/domain/usecases/store/StoreVisitSyncRecordUseCase.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/sync/domain/usecases/store/StoreVisitSyncRecordUseCase.kt
@@ -44,7 +44,16 @@ class StoreVisitSyncRecordUseCase @Inject constructor(
     }
 
     private suspend fun update(syncRecord: VisitSyncRecord.Update) {
-        val visit = syncRecord.toDomain()
+        var visit = syncRecord.toDomain()
+        // The server retains the original scheduled startDatetime even after a visit is completed.
+        // If we have an uploaded DraftVisitEncounter, use its startDatetime (the actual admin date).
+        val draftState = draftVisitEncounterRepository.findDraftStateByVisitUuid(visit.visitUuid)
+        if (draftState == DraftState.UPLOADED) {
+            val draftEncounter = draftVisitEncounterRepository.findByVisitUuid(visit.visitUuid)
+            if (draftEncounter != null) {
+                visit = visit.copy(startDatetime = draftEncounter.startDatetime)
+            }
+        }
         visitRepository.insert(visit, orReplace = true)
         onInsertSuccess(visit)
     }

--- a/app/src/main/java/com/jnj/vaccinetracker/sync/domain/usecases/store/StoreVisitSyncRecordUseCase.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/sync/domain/usecases/store/StoreVisitSyncRecordUseCase.kt
@@ -45,8 +45,6 @@ class StoreVisitSyncRecordUseCase @Inject constructor(
 
     private suspend fun update(syncRecord: VisitSyncRecord.Update) {
         var visit = syncRecord.toDomain()
-        // The server retains the original scheduled startDatetime even after a visit is completed.
-        // If we have an uploaded DraftVisitEncounter, use its startDatetime (the actual admin date).
         val draftState = draftVisitEncounterRepository.findDraftStateByVisitUuid(visit.visitUuid)
         if (draftState == DraftState.UPLOADED) {
             val draftEncounter = draftVisitEncounterRepository.findByVisitUuid(visit.visitUuid)

--- a/app/src/main/java/com/jnj/vaccinetracker/sync/domain/usecases/upload/UploadDraftVisitEncounterUseCase.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/sync/domain/usecases/upload/UploadDraftVisitEncounterUseCase.kt
@@ -19,7 +19,7 @@ class UploadDraftVisitEncounterUseCase @Inject constructor(
         startDatetime = startDatetime,
         locationUuid = locationUuid,
         attributes = attributes.map { AttributeDto(it.key, it.value) },
-        observations = observations.map { UpdateVisitObservationDto(it.key, it.value) },
+        observations = observations.filter { it.value.isNotEmpty() }.map { UpdateVisitObservationDto(it.key, it.value) },
     )
 
     private suspend fun updateDraftStates(uploadedDraftVisitEncounter: DraftVisitEncounter) {

--- a/app/src/main/java/com/jnj/vaccinetracker/visit/VisitViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visit/VisitViewModel.kt
@@ -453,7 +453,10 @@ class VisitViewModel @Inject constructor(
             val substancesGroupConfig = configurationManager.getSubstancesGroupConfig()
             val ageFiltered = substancesForVisitType.filter { substance ->
                 val config = substancesConfig.find { it.conceptName == substance.conceptName }
-                config == null || childAgeInWeeks >= (config.weeksAfterBirth - config.weeksAfterBirthLowWindow)
+                    ?: return@filter true
+                val minWeeks = config.weeksAfterBirth - config.weeksAfterBirthLowWindow
+                val maxWeeks = config.weeksAfterBirth + config.weeksAfterBirthUpWindow
+                childAgeInWeeks in minWeeks..maxWeeks
             }
             SubstancesDataUtil.applyVaccinesCatchUpSchedule(
                 ageFiltered, childAgeInWeeks, patientVisits.value ?: emptyList(),

--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
@@ -83,7 +83,14 @@ class VisitsListViewModel @Inject constructor(
             val convertedDraftVisits = draftVisits.map { convertDraftVisitToVisitOffline(it) }
 
             val draftVisitParticipantIds = convertedDraftVisits.map { it.participantUuid }.toSet()
-            val filteredScheduledVisits = uniqueScheduledVisits.filter { scheduledVisit -> !draftVisitParticipantIds.contains(scheduledVisit.participantUuid)}
+            // Also exclude visits that were administered offline (DraftVisitEncounter exists) but not yet synced
+            val administeredVisitUuids = draftVisitEncounterRepository
+                .findVisitsBeforeDate(tomorrowMidnight)
+                .map { it.visitUuid }.toSet()
+            val filteredScheduledVisits = uniqueScheduledVisits.filter { scheduledVisit ->
+                !draftVisitParticipantIds.contains(scheduledVisit.participantUuid) &&
+                !administeredVisitUuids.contains(scheduledVisit.visitUuid)
+            }
 
             val combinedScheduledVisits = convertedDraftVisits + filteredScheduledVisits
             visitDTOs.value = createVisitDTOList(combinedScheduledVisits)

--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
@@ -83,7 +83,6 @@ class VisitsListViewModel @Inject constructor(
             val convertedDraftVisits = draftVisits.map { convertDraftVisitToVisitOffline(it) }
 
             val draftVisitParticipantIds = convertedDraftVisits.map { it.participantUuid }.toSet()
-            // Also exclude visits that were administered offline (DraftVisitEncounter exists) but not yet synced
             val administeredVisitUuids = draftVisitEncounterRepository
                 .findVisitsBeforeDate(tomorrowMidnight)
                 .map { it.visitUuid }.toSet()


### PR DESCRIPTION
# Bugs Fixed 

- Visit history showing wrong date (StoreVisitSyncRecordUseCase.kt)
- Scheduled report showing already-administered CHP visits (VisitsListViewModel.kt)
- Report date filter showing wrong "today" (VaccinesOverviewFragment.kt, Hmis105ChildHealthFragment.kt, Hmis105ReportFragment.kt)
- Empty observation sync errors (UploadDraftVisitEncounterUseCase.kt)
- TotalSyncScopeRecordCountMismatchException missing field (exceptions.kt, ValidateSyncResponseUseCase.kt)
  