### PR TITLE
Fix wrong visit type shown in scheduled visits report

### DIFF
--- a/app/src/main/java/com/jnj/vaccinetracker/common/util/SubstancesDataUtil.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/common/util/SubstancesDataUtil.kt
@@ -492,5 +492,28 @@ class SubstancesDataUtil {
                 false
             }
         }
+
+        fun getDoseNumberToVisitTypeMap(substancesConfig: SubstancesConfig): Map<Int, String> {
+            val visitTypesByWeeks = substancesConfig
+                .groupBy { it.weeksAfterBirth }
+                .toSortedMap()
+                .map { it.value.first().visitType }
+
+            return visitTypesByWeeks.mapIndexed { index, visitType ->
+                (index + 1) to visitType
+            }.toMap()
+        }
+
+        fun getVisitTypeForDoseNumber(doseNumber: String, substancesConfig: SubstancesConfig): String {
+            if (doseNumber.isEmpty()) return "Unknown"
+            val doseNum = doseNumber.toIntOrNull() ?: return "Unknown"
+            val doseNumToVisitTypeMap = getDoseNumberToVisitTypeMap(substancesConfig)
+            return doseNumToVisitTypeMap[doseNum] ?: "Unknown"
+        }
+
+        fun getDoseNumberForVisitType(visitType: String, substancesConfig: SubstancesConfig): Int {
+            val index = getVisitTypesInOrder(substancesConfig).indexOf(visitType)
+            return if (index >= 0) index + 1 else 1
+        }
     }
 }

--- a/app/src/main/java/com/jnj/vaccinetracker/register/screens/HistoricalDataForVisitTypeFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/register/screens/HistoricalDataForVisitTypeFragment.kt
@@ -541,6 +541,7 @@ class HistoricalDataForVisitTypeFragment :
       val locationUuid = syncSettingsRepository.getSiteUuid()
          ?: throw NoSiteUuidAvailableException("Location not available")
       val visitType = findVisitType(participant, visitDate)
+        val doseNumber = SubstancesDataUtil.getDoseNumberForVisitType(visitType, configurationManager.getSubstancesConfig())
       return CreateVisit(
          participantUuid = participant.participantUuid,
          visitType = Constants.VISIT_TYPE_DOSING,
@@ -550,6 +551,7 @@ class HistoricalDataForVisitTypeFragment :
             Constants.ATTRIBUTE_VISIT_STATUS to Constants.VISIT_STATUS_OCCURRED,
             Constants.ATTRIBUTE_OPERATOR to operatorUuid,
             Constants.ATTRIBUTE_VISIT_TYPE_VXNAID to visitType,
+                Constants.ATTRIBUTE_VISIT_DOSE_NUMBER to doseNumber.toString()
          )
       )
    }

--- a/app/src/main/java/com/jnj/vaccinetracker/register/screens/HistoricalDataForVisitTypeFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/register/screens/HistoricalDataForVisitTypeFragment.kt
@@ -541,7 +541,7 @@ class HistoricalDataForVisitTypeFragment :
       val locationUuid = syncSettingsRepository.getSiteUuid()
          ?: throw NoSiteUuidAvailableException("Location not available")
       val visitType = findVisitType(participant, visitDate)
-        val doseNumber = SubstancesDataUtil.getDoseNumberForVisitType(visitType, configurationManager.getSubstancesConfig())
+      val doseNumber = SubstancesDataUtil.getDoseNumberForVisitType(visitType, configurationManager.getSubstancesConfig())
       return CreateVisit(
          participantUuid = participant.participantUuid,
          visitType = Constants.VISIT_TYPE_DOSING,
@@ -551,7 +551,7 @@ class HistoricalDataForVisitTypeFragment :
             Constants.ATTRIBUTE_VISIT_STATUS to Constants.VISIT_STATUS_OCCURRED,
             Constants.ATTRIBUTE_OPERATOR to operatorUuid,
             Constants.ATTRIBUTE_VISIT_TYPE_VXNAID to visitType,
-                Constants.ATTRIBUTE_VISIT_DOSE_NUMBER to doseNumber.toString()
+            Constants.ATTRIBUTE_VISIT_DOSE_NUMBER to doseNumber.toString()
          )
       )
    }

--- a/app/src/main/java/com/jnj/vaccinetracker/visit/VisitViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visit/VisitViewModel.kt
@@ -664,4 +664,3 @@ class VisitViewModel @Inject constructor(
         return true
     }
 }
-

--- a/app/src/main/java/com/jnj/vaccinetracker/visit/VisitViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visit/VisitViewModel.kt
@@ -544,6 +544,7 @@ class VisitViewModel @Inject constructor(
         val locationUuid = syncSettingsRepository.getSiteUuid()
             ?: throw NoSiteUuidAvailableException("Location not available")
         val visitType = dosingVisit.value?.visitTypeVxnaid ?: findVisitType(participant, visitDate) // it assigns visit type of current visit to new rescheduled one
+        val doseNumber = SubstancesDataUtil.getDoseNumberForVisitType(visitType, configurationManager.getSubstancesConfig())
         return CreateVisit(
             participantUuid = participant.participantUuid,
             visitType = Constants.VISIT_TYPE_DOSING,
@@ -553,6 +554,7 @@ class VisitViewModel @Inject constructor(
                 Constants.ATTRIBUTE_VISIT_STATUS to Constants.VISIT_STATUS_SCHEDULED,
                 Constants.ATTRIBUTE_OPERATOR to operatorUuid,
                 Constants.ATTRIBUTE_VISIT_TYPE_VXNAID to visitType,
+                Constants.ATTRIBUTE_VISIT_DOSE_NUMBER to doseNumber.toString()
             )
         )
     }

--- a/app/src/main/java/com/jnj/vaccinetracker/visit/dialog/RescheduleVisitDialog.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visit/dialog/RescheduleVisitDialog.kt
@@ -206,7 +206,7 @@ class RescheduleVisitDialog @Inject constructor() : BaseDialogFragment(),
       val locationUuid = syncSettingsRepository.getSiteUuid()
          ?: throw NoSiteUuidAvailableException("Location not available")
       val visitType = findVisitType(participant, visitDate)
-        val doseNumber = SubstancesDataUtil.getDoseNumberForVisitType(visitType, configurationManager.getSubstancesConfig())
+      val doseNumber = SubstancesDataUtil.getDoseNumberForVisitType(visitType, configurationManager.getSubstancesConfig())
       return CreateVisit(
          participantUuid = participant.participantUuid,
          visitType = Constants.VISIT_TYPE_DOSING,
@@ -216,7 +216,7 @@ class RescheduleVisitDialog @Inject constructor() : BaseDialogFragment(),
             Constants.ATTRIBUTE_VISIT_STATUS to Constants.VISIT_STATUS_SCHEDULED,
             Constants.ATTRIBUTE_OPERATOR to operatorUuid,
             Constants.ATTRIBUTE_VISIT_TYPE_VXNAID to visitType,
-                Constants.ATTRIBUTE_VISIT_DOSE_NUMBER to doseNumber.toString()
+            Constants.ATTRIBUTE_VISIT_DOSE_NUMBER to doseNumber.toString()
          )
       )
    }

--- a/app/src/main/java/com/jnj/vaccinetracker/visit/dialog/RescheduleVisitDialog.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visit/dialog/RescheduleVisitDialog.kt
@@ -206,6 +206,7 @@ class RescheduleVisitDialog @Inject constructor() : BaseDialogFragment(),
       val locationUuid = syncSettingsRepository.getSiteUuid()
          ?: throw NoSiteUuidAvailableException("Location not available")
       val visitType = findVisitType(participant, visitDate)
+        val doseNumber = SubstancesDataUtil.getDoseNumberForVisitType(visitType, configurationManager.getSubstancesConfig())
       return CreateVisit(
          participantUuid = participant.participantUuid,
          visitType = Constants.VISIT_TYPE_DOSING,
@@ -215,6 +216,7 @@ class RescheduleVisitDialog @Inject constructor() : BaseDialogFragment(),
             Constants.ATTRIBUTE_VISIT_STATUS to Constants.VISIT_STATUS_SCHEDULED,
             Constants.ATTRIBUTE_OPERATOR to operatorUuid,
             Constants.ATTRIBUTE_VISIT_TYPE_VXNAID to visitType,
+                Constants.ATTRIBUTE_VISIT_DOSE_NUMBER to doseNumber.toString()
          )
       )
    }

--- a/app/src/main/java/com/jnj/vaccinetracker/visit/dialog/VisitRegisteredSuccessDialog.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visit/dialog/VisitRegisteredSuccessDialog.kt
@@ -19,7 +19,6 @@ import androidx.lifecycle.lifecycleScope
 import com.jnj.vaccinetracker.R
 import com.jnj.vaccinetracker.common.data.managers.ConfigurationManager
 import com.jnj.vaccinetracker.common.data.managers.ParticipantManager
-import com.jnj.vaccinetracker.common.data.managers.VisitManager
 import com.jnj.vaccinetracker.common.data.models.Constants
 import com.jnj.vaccinetracker.common.data.repositories.UserRepository
 import com.jnj.vaccinetracker.common.domain.entities.CreateVisit
@@ -87,7 +86,6 @@ class VisitRegisteredSuccessDialog : BaseDialogFragment(), ScheduleVisitDatePick
     @Inject lateinit var userRepository: UserRepository
     @Inject lateinit var syncSettingsRepository: SyncSettingsRepository
     @Inject lateinit var configurationManager: ConfigurationManager
-    @Inject lateinit var visitManager: VisitManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -178,6 +176,7 @@ class VisitRegisteredSuccessDialog : BaseDialogFragment(), ScheduleVisitDatePick
         val locationUuid = syncSettingsRepository.getSiteUuid()
             ?: throw NoSiteUuidAvailableException("Location not available")
         val visitType = findVisitTypeOfNextVisit()
+        val doseNumber = SubstancesDataUtil.getDoseNumberForVisitType(visitType, configurationManager.getSubstancesConfig())
         return CreateVisit(
             participantUuid = participant.participantUuid,
             visitType = Constants.VISIT_TYPE_DOSING,
@@ -187,26 +186,19 @@ class VisitRegisteredSuccessDialog : BaseDialogFragment(), ScheduleVisitDatePick
                 Constants.ATTRIBUTE_VISIT_STATUS to Constants.VISIT_STATUS_SCHEDULED,
                 Constants.ATTRIBUTE_OPERATOR to operatorUuid,
                 Constants.ATTRIBUTE_VISIT_TYPE_VXNAID to visitType,
+                Constants.ATTRIBUTE_VISIT_DOSE_NUMBER to doseNumber.toString()
             )
         )
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
     private suspend fun findVisitTypeOfNextVisit(): String {
-        val participantBirthDate = participant!!.birthDateText
-        val participantVisits = visitManager.getVisitsForParticipant(participant!!.participantUuid)
-        val currentVisitType = SubstancesDataUtil.getVisitTypeForCurrentVisit(participantBirthDate, participantVisits, configurationManager)
+        val currentVisitType = viewModel.selectedVisitType.value ?: return ""
         val substancesConfig = configurationManager.getSubstancesConfig()
-        val currentVaccine = substancesConfig.find { it.visitType == currentVisitType }
-        if (currentVaccine == null) {
-            return ""
-        }
-        val nextVaccine = substancesConfig.filter { it.weeksAfterBirth > currentVaccine.weeksAfterBirth }
-            .minByOrNull { it.weeksAfterBirth }
-        if (nextVaccine == null) {
-            return ""
-        }
-
+        val currentVaccine = substancesConfig.find { it.visitType == currentVisitType } ?: return ""
+        val nextVaccine = substancesConfig
+            .filter { it.weeksAfterBirth > currentVaccine.weeksAfterBirth }
+            .minByOrNull { it.weeksAfterBirth } ?: return ""
         return nextVaccine.visitType
     }
 

--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/dto/VisitDataDTO.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/dto/VisitDataDTO.kt
@@ -16,28 +16,5 @@ data class VisitDataDTO(
 ) {
     val formattedStartDateTime: String get() = DateUtil.convertDateToString(startDatetime, DateFormat.FORMAT_DATE.toString())
     val visitype: String
-    get() {
-        val visitTypeVxnaid = attributes["Visit type Vxnaid"]
-        if (!visitTypeVxnaid.isNullOrEmpty()) {
-            return visitTypeVxnaid
-        } else {
-            val doseNumber = attributes["Dose number"] ?: attributes["Dose Number"] ?: ""
-            return when (doseNumber) {
-                "1" -> "At Birth"
-                "2" -> "6 weeks"
-                "3" -> "10 weeks"
-                "4" -> "14 weeks"
-                "5" -> "6 months"
-                "6" -> "7 months"
-                "7" -> "8 months"
-                "8" -> "9 months"
-                "9" -> "1 year"
-                "10" -> "18 months"
-                "11" -> "2 years"
-                else -> "Unknown"
-            }
-        }
-    }
-
-
+        get() = attributes["Visit type Vxnaid"]?.takeIf { it.isNotEmpty() } ?: "Unknown"
 }

--- a/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visitsoverview/model/VisitsListViewModel.kt
@@ -15,6 +15,7 @@ import com.jnj.vaccinetracker.common.data.models.ChildHealthPlusService
 import com.jnj.vaccinetracker.common.data.models.Constants
 import com.jnj.vaccinetracker.common.data.repositories.UserRepository
 import com.jnj.vaccinetracker.common.util.DateUtil
+import com.jnj.vaccinetracker.common.util.SubstancesDataUtil
 import com.soywiz.klock.DateFormat
 import com.jnj.vaccinetracker.common.domain.entities.DraftVisit
 import com.jnj.vaccinetracker.common.domain.entities.DraftVisitEncounter
@@ -186,6 +187,7 @@ class VisitsListViewModel @Inject constructor(
             .findByParticipantUuids(visits.map { it.participantUuid }.toSet())
             .groupBy { it.participantUuid }
 
+        val substancesConfig = configurationManager.getSubstancesConfig()
         val chpServiceKeyToDisplay = ChildHealthPlusService.values()
             .associate { it.serviceKey to it.displayName }
 
@@ -203,10 +205,11 @@ class VisitsListViewModel @Inject constructor(
         // Regular visits: one row per visit, unchanged behaviour.
         for (visit in regularVisits) {
             val participant = participantsMap[visit.participantUuid]?.getOrNull(0) ?: continue
+            val attributes = resolveVisitTypeAttribute(visit.attributes, substancesConfig)
             visitDataDTOList.add(VisitDataDTO(
                 visitUuid      = visit.visitUuid,
                 startDatetime  = visit.startDatetime,
-                attributes     = visit.attributes,
+                attributes     = attributes,
                 observations   = visit.observations,
                 visitType      = visit.visitType,
                 participant    = participant
@@ -252,6 +255,19 @@ class VisitsListViewModel @Inject constructor(
         visitDataDTOList.sortByDescending { it.startDatetime.time }
         Log.d("VisitsListViewModel", "Visit count: ${visitDataDTOList.size}, Unique participant count: ${participantsMap.size}")
         return visitDataDTOList
+    }
+
+    private fun resolveVisitTypeAttribute(
+        attributes: Map<String, String>,
+        substancesConfig: List<com.jnj.vaccinetracker.common.domain.entities.Substance>
+    ): Map<String, String> {
+        if (!attributes[Constants.ATTRIBUTE_VISIT_TYPE_VXNAID].isNullOrEmpty()) return attributes
+        val doseNumber = attributes[Constants.ATTRIBUTE_VISIT_DOSE_NUMBER]
+            ?: attributes["Dose Number"]
+            ?: return attributes
+        val visitType = SubstancesDataUtil.getVisitTypeForDoseNumber(doseNumber, substancesConfig)
+        if (visitType == "Unknown") return attributes
+        return attributes + (Constants.ATTRIBUTE_VISIT_TYPE_VXNAID to visitType)
     }
 
     override fun saveInstanceState(outState: Bundle) {}


### PR DESCRIPTION
# Fix wrong visit type shown in scheduled visits report after scheduling next visit                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                            
  - VisitRegisteredSuccessDialog.findVisitTypeOfNextVisit() was calling                                                                                                                                                                                                                                                     
    getVisitTypeForCurrentVisit() which returns the next visit after the                                                                                                                                                                                                                                                    
    last OCCURRED one, then finding the visit after that — one step too far.                                                                                                                                                                                                                                                
    Now uses viewModel.selectedVisitType (the just-completed visit type)                                                                                                                                                                                                                                                    
    as the base, consistent with findProposedNextVisitDateAsLocalDate().                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                            
  - Replace hardcoded dose-number→visit-type map in VisitDataDTO with                                                                                                                                                                                                                                                       
    config-driven resolution in VisitsListViewModel. Visit type is now                                                                                                                                                                                                                                                      
    resolved from SubstancesDataUtil before building each DTO, so the                                                                                                                                                                                                                                                       
    display always reflects the configured schedule.                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                            
  - Extract getDoseNumberForVisitType() into SubstancesDataUtil and remove                                                                                                                                                                                                                                                  
    the four identical calculateDoseNumberForVisitType() copies from                                                                                                                                                                                                                                                        
    VisitRegisteredSuccessDialog, RescheduleVisitDialog, VisitViewModel,                                                                                                                                                                                                                                                    
    and HistoricalDataForVisitTypeFragment.