### PR TITLE
CHS age field

### DIFF
--- a/app/src/main/java/com/jnj/vaccinetracker/childhealthplus/model/ChildHealthPlusViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/childhealthplus/model/ChildHealthPlusViewModel.kt
@@ -61,6 +61,8 @@ class ChildHealthPlusViewModel @Inject constructor(
     val childFirstName = mutableLiveData<String>()
     val childLastName = mutableLiveData<String>()
     val dateOfBirth = mutableLiveData<Date>()
+    val isDobUnknown = mutableLiveBoolean(false)
+    val ageYears = mutableLiveData<String>()
     val gender = mutableLiveData<String>()
     val telephone = mutableLiveData<String>()
     val phoneCountryCode = mutableLiveData<String>()
@@ -175,6 +177,12 @@ class ChildHealthPlusViewModel @Inject constructor(
             errorMessage.value = errors.joinToString(", ")
             return
         }
+        if (isDobUnknown.value == true && dateOfBirth.value == null) {
+            val years = ageYears.value?.trim()?.toIntOrNull() ?: 0
+            val cal = Calendar.getInstance()
+            cal.add(Calendar.YEAR, -years)
+            dateOfBirth.value = cal.time
+        }
         ensureGeneratedChildId()
         currentStage.value = WorkflowStage.SERVICE_SELECTION
     }
@@ -275,7 +283,7 @@ class ChildHealthPlusViewModel @Inject constructor(
                         bestContactTime = bestContactTime.value,
                         gender = genderEnum,
                         birthDate = com.soywiz.klock.DateTime.fromUnix(dob.time),
-                        isBirthDateEstimated = false,
+                        isBirthDateEstimated = isDobUnknown.value == true,
                         telephone = fullPhone,
                         siteUuid = siteUuid,
                         language = language.value,
@@ -503,8 +511,14 @@ class ChildHealthPlusViewModel @Inject constructor(
             errors.add(resourcesWrapper.getString(R.string.child_health_plus_first_name_required))
         if (childLastName.value.isNullOrBlank())
             errors.add(resourcesWrapper.getString(R.string.child_health_plus_last_name_required))
-        if (dateOfBirth.value == null)
-            errors.add(resourcesWrapper.getString(R.string.child_health_plus_dob_required))
+        if (isDobUnknown.value == true) {
+            val months = ageYears.value?.trim()?.toIntOrNull()
+            if (months == null || months <= 0)
+                errors.add(resourcesWrapper.getString(R.string.child_health_plus_age_required))
+        } else {
+            if (dateOfBirth.value == null)
+                errors.add(resourcesWrapper.getString(R.string.child_health_plus_dob_required))
+        }
         if (gender.value.isNullOrBlank())
             errors.add(resourcesWrapper.getString(R.string.child_health_plus_sex_required))
         return errors

--- a/app/src/main/java/com/jnj/vaccinetracker/childhealthplus/model/ChildHealthPlusViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/childhealthplus/model/ChildHealthPlusViewModel.kt
@@ -512,8 +512,8 @@ class ChildHealthPlusViewModel @Inject constructor(
         if (childLastName.value.isNullOrBlank())
             errors.add(resourcesWrapper.getString(R.string.child_health_plus_last_name_required))
         if (isDobUnknown.value == true) {
-            val months = ageYears.value?.trim()?.toIntOrNull()
-            if (months == null || months <= 0)
+            val years = ageYears.value?.trim()?.toIntOrNull()
+            if (years == null || years <= 0)
                 errors.add(resourcesWrapper.getString(R.string.child_health_plus_age_required))
         } else {
             if (dateOfBirth.value == null)

--- a/app/src/main/java/com/jnj/vaccinetracker/childhealthplus/presentation/screens/ChildHealthPlusClientInfoFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/childhealthplus/presentation/screens/ChildHealthPlusClientInfoFragment.kt
@@ -77,6 +77,12 @@ class ChildHealthPlusClientInfoFragment : BaseFragment(),
     }
 
     private fun setupDobUnknown() {
+        val isUnknown = viewModel.isDobUnknown.value == true
+        binding.checkboxDobUnknown.isChecked = isUnknown
+        binding.layoutDateOfBirth.visibility = if (isUnknown) View.GONE else View.VISIBLE
+        binding.layoutAgeMonths.visibility = if (isUnknown) View.VISIBLE else View.GONE
+        viewModel.ageYears.value?.let { binding.editAgeMonths.setText(it) }
+
         binding.checkboxDobUnknown.setOnCheckedChangeListener { _, isChecked ->
             viewModel.isDobUnknown.value = isChecked
             binding.layoutDateOfBirth.visibility = if (isChecked) View.GONE else View.VISIBLE

--- a/app/src/main/java/com/jnj/vaccinetracker/childhealthplus/presentation/screens/ChildHealthPlusClientInfoFragment.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/childhealthplus/presentation/screens/ChildHealthPlusClientInfoFragment.kt
@@ -37,6 +37,7 @@ class ChildHealthPlusClientInfoFragment : BaseFragment(),
 
         setupSexRadioButtons()
         setupDatePicker()
+        setupDobUnknown()
         setupPhoneInput()
         setupLanguageDropdown()
         setupBestContactTime()
@@ -72,6 +73,24 @@ class ChildHealthPlusClientInfoFragment : BaseFragment(),
                 viewModel.dateOfBirth.value = selectedDate
                 binding.dateOfBirth.setText(dateFormat.format(selectedDate))
             }
+        }
+    }
+
+    private fun setupDobUnknown() {
+        binding.checkboxDobUnknown.setOnCheckedChangeListener { _, isChecked ->
+            viewModel.isDobUnknown.value = isChecked
+            binding.layoutDateOfBirth.visibility = if (isChecked) View.GONE else View.VISIBLE
+            binding.layoutAgeMonths.visibility = if (isChecked) View.VISIBLE else View.GONE
+            if (isChecked) {
+                viewModel.dateOfBirth.value = null
+                binding.dateOfBirth.setText("")
+            } else {
+                viewModel.ageYears.value = null
+                binding.editAgeMonths.setText("")
+            }
+        }
+        binding.editAgeMonths.doAfterTextChanged { text ->
+            viewModel.ageYears.value = text?.toString()
         }
     }
 

--- a/app/src/main/res/layout/fragment_child_health_plus_client_info.xml
+++ b/app/src/main/res/layout/fragment_child_health_plus_client_info.xml
@@ -149,6 +149,7 @@
 
                 <!-- Date of Birth -->
                 <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/layout_date_of_birth"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/margin_16_32">
@@ -160,6 +161,32 @@
                         android:hint="@string/child_health_plus_client_dob_label"
                         android:inputType="date"
                         android:focusable="false" />
+
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <!-- DOB Unknown checkbox -->
+                <CheckBox
+                    android:id="@+id/checkbox_dob_unknown"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_8_16"
+                    android:text="@string/child_health_plus_dob_unknown"
+                    android:textSize="@dimen/chp_text_input" />
+
+                <!-- Age field (shown when DOB is unknown) -->
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/layout_age_months"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_8_16"
+                    android:visibility="gone">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/edit_age_months"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:hint="@string/child_health_plus_age_hint"
+                        android:inputType="number" />
 
                 </com.google.android.material.textfield.TextInputLayout>
 

--- a/app/src/main/res/layout/fragment_child_health_plus_client_info.xml
+++ b/app/src/main/res/layout/fragment_child_health_plus_client_info.xml
@@ -147,48 +147,72 @@
 
                 </LinearLayout>
 
-                <!-- Date of Birth -->
-                <com.google.android.material.textfield.TextInputLayout
-                    android:id="@+id/layout_date_of_birth"
+                <!-- Date of Birth section -->
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/margin_16_32">
+                    android:layout_marginTop="@dimen/margin_16_32"
+                    android:orientation="vertical">
 
-                    <com.google.android.material.textfield.TextInputEditText
-                        android:id="@+id/date_of_birth"
+                    <!-- Label row: "Date of Birth *" + "Date of birth unknown" checkbox -->
+                    <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:hint="@string/child_health_plus_client_dob_label"
-                        android:inputType="date"
-                        android:focusable="false" />
+                        android:gravity="center_vertical"
+                        android:orientation="horizontal">
 
-                </com.google.android.material.textfield.TextInputLayout>
+                        <TextView
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/child_health_plus_client_dob_label"
+                            android:textAppearance="@style/LabelText" />
 
-                <!-- DOB Unknown checkbox -->
-                <CheckBox
-                    android:id="@+id/checkbox_dob_unknown"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/margin_8_16"
-                    android:text="@string/child_health_plus_dob_unknown"
-                    android:textSize="@dimen/chp_text_input" />
+                        <CheckBox
+                            android:id="@+id/checkbox_dob_unknown"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/child_health_plus_dob_unknown"
+                            android:textSize="@dimen/chp_text_input"
+                            android:textColor="?android:attr/textColorPrimary" />
 
-                <!-- Age field (shown when DOB is unknown) -->
-                <com.google.android.material.textfield.TextInputLayout
-                    android:id="@+id/layout_age_months"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/margin_8_16"
-                    android:visibility="gone">
+                    </LinearLayout>
 
-                    <com.google.android.material.textfield.TextInputEditText
-                        android:id="@+id/edit_age_months"
+                    <!-- Date picker input -->
+                    <com.google.android.material.textfield.TextInputLayout
+                        android:id="@+id/layout_date_of_birth"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:hint="@string/child_health_plus_age_hint"
-                        android:inputType="number" />
+                        android:layout_marginTop="@dimen/margin_8_16">
 
-                </com.google.android.material.textfield.TextInputLayout>
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/date_of_birth"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:hint="@string/child_health_plus_client_dob_hint"
+                            android:inputType="date"
+                            android:focusable="false" />
+
+                    </com.google.android.material.textfield.TextInputLayout>
+
+                    <!-- Age input (shown when date of birth is unknown) -->
+                    <com.google.android.material.textfield.TextInputLayout
+                        android:id="@+id/layout_age_months"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/margin_8_16"
+                        android:visibility="gone">
+
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/edit_age_months"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:hint="@string/child_health_plus_age_hint"
+                            android:inputType="number" />
+
+                    </com.google.android.material.textfield.TextInputLayout>
+
+                </LinearLayout>
 
                 <!-- Gender -->
                 <LinearLayout

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -616,6 +616,7 @@
     <string name="child_health_plus_client_info_title">Client Details</string>
     <string name="child_health_plus_client_name_label">Client Name</string>
     <string name="child_health_plus_client_dob_label">Date of Birth *</string>
+    <string name="child_health_plus_client_dob_hint">Tap to select date</string>
     <string name="child_health_plus_client_sex_label">Gender *</string>
     <string name="child_health_plus_client_contact_label">Contact Information</string>
     <string name="child_health_plus_mother_name_label">Mother\'s Name</string>
@@ -638,8 +639,8 @@
     <string name="child_health_plus_validation_error">Please complete all required fields</string>
     <string name="child_health_plus_name_required">Client name is required</string>
     <string name="child_health_plus_dob_required">Date of birth is required</string>
-    <string name="child_health_plus_dob_unknown">DOB Unknown</string>
-    <string name="child_health_plus_age_hint">Age (in years) *</string>
+    <string name="child_health_plus_dob_unknown">Date of birth unknown</string>
+    <string name="child_health_plus_age_hint">Age in years *</string>
     <string name="child_health_plus_age_required">Age is required when date of birth is unknown</string>
     <string name="child_health_plus_sex_required">Gender is required</string>
     <string name="child_health_plus_contact_required">Contact information is required</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -638,6 +638,9 @@
     <string name="child_health_plus_validation_error">Please complete all required fields</string>
     <string name="child_health_plus_name_required">Client name is required</string>
     <string name="child_health_plus_dob_required">Date of birth is required</string>
+    <string name="child_health_plus_dob_unknown">DOB Unknown</string>
+    <string name="child_health_plus_age_hint">Age (in years) *</string>
+    <string name="child_health_plus_age_required">Age is required when date of birth is unknown</string>
     <string name="child_health_plus_sex_required">Gender is required</string>
     <string name="child_health_plus_contact_required">Contact information is required</string>
     <string name="child_health_plus_mother_required">Mother\'s name is required</string>


### PR DESCRIPTION
  - "Date of birth unknown" checkbox sits on the same row as the "Date of Birth *" label                                                                                                                                                                                                                                    
  - Checking it hides the date picker and shows an "Age in years *" input field                                                                                                                                                                                                                                             
  - Unchecking it hides the age field and shows the date picker again, clearing the previous value                                                                                                                                                                                                                          
  - Validation requires either a date of birth or a valid age (> 0) before proceeding                                                                                                                                                                                                                                       
  - On submit, the entered age is converted to an estimated birth date and saved with isBirthDateEstimated = true — same pattern as the normal registration                                                                                                                                                                 
  - Back-navigation correctly restores the checkbox state, field visibility, and age text from the ViewModel