### PR TITLE
 Fix sync errors

### DIFF
--- a/app/src/main/java/com/jnj/vaccinetracker/common/data/database/daos/ParticipantDao.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/common/data/database/daos/ParticipantDao.kt
@@ -59,6 +59,9 @@ interface ParticipantDao : ParticipantDaoBase<ParticipantEntity, RoomParticipant
     @Delete(entity = ParticipantEntity::class)
     override suspend fun delete(deleteParticipantModel: RoomDeleteParticipantModel): Int
 
+    @Query("DELETE FROM participant WHERE participantId = :participantId AND participantUuid != :participantUuid")
+    suspend fun deleteConflictingByParticipantId(participantId: String, participantUuid: String): Int
+
     @Query("delete from participant")
     override suspend fun deleteAll()
 

--- a/app/src/main/java/com/jnj/vaccinetracker/common/data/database/repositories/ParticipantRepository.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/common/data/database/repositories/ParticipantRepository.kt
@@ -121,6 +121,12 @@ class ParticipantRepository @Inject constructor(
                 if (isDeletedByUuid) {
                     logInfo("deleted participant for replace ${model.participantUuid} or participantId ${model.participantId}")
                 }
+                // A different-UUID row with the same participantId would violate the UNIQUE
+                // constraint on participantId even after the UUID-based delete above.
+                val isDeletedById = participantDao.deleteConflictingByParticipantId(model.participantId, model.participantUuid) > 0
+                if (isDeletedById) {
+                    logInfo("deleted conflicting participant with same participantId ${model.participantId} different uuid")
+                }
             }
 
             val insertedParticipant = participantDao.insert(model.toPersistence()) > 0

--- a/app/src/main/java/com/jnj/vaccinetracker/common/domain/entities/Sites.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/common/domain/entities/Sites.kt
@@ -15,7 +15,7 @@ data class Site(
     val name: String,
     val country: String,
     val cluster: String = "",
-    val countryCode: String = "",
+    val countryCode: String? = null,
     val siteCode: String = "",
     val parentLocationUuid: String? = null,
 ) {

--- a/app/src/main/java/com/jnj/vaccinetracker/common/domain/usecases/GenerateUniqueParticipantIdUseCase.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/common/domain/usecases/GenerateUniqueParticipantIdUseCase.kt
@@ -27,7 +27,7 @@ class GenerateUniqueParticipantIdUseCase @Inject constructor(
         findParticipantByParticipantIdUseCase.findDeletedParticipantbyId(participantId) !=null
 
     private suspend fun generateUniqueParticipantId(site: Site, deviceName: String, sequenceNumber: Int): String {
-        val countryCode = site.countryCode
+        val countryCode = site.countryCode.orEmpty()
         val participantIdCandidate = createParticipantId(countryCode = countryCode, deviceName = deviceName, sequenceNumber)
         return if (doesParticipantIdExists(participantIdCandidate)) {
             // current sequence is already in use so create the next one and store it

--- a/app/src/main/java/com/jnj/vaccinetracker/participantflow/screens/ParticipantFlowPhoneNumberViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/participantflow/screens/ParticipantFlowPhoneNumberViewModel.kt
@@ -45,7 +45,7 @@ class ParticipantFlowPhoneNumberViewModel @Inject constructor(
                 val site = syncSettingsRepository.getSiteUuid()?.let { configurationManager.getSiteByUuid(it) } ?: throw NoSiteUuidAvailableException()
                 logInfo("site country ${site.countryCode} ${site.country}")
                 defaultPhoneCountryCode.set(prefCountryCode.get())
-                prefCountryCode.get()?: defaultPhoneCountryCode.set(site.countryCode)
+                prefCountryCode.get()?: defaultPhoneCountryCode.set(site.countryCode.orEmpty())
                 loading.set(false)
             } catch (ex: Throwable) {
                 yield()

--- a/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantParticipantDetailsViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/register/screens/RegisterParticipantParticipantDetailsViewModel.kt
@@ -341,8 +341,8 @@ class RegisterParticipantParticipantDetailsViewModel @Inject constructor(
     }
 
     private fun onSiteAndConfigurationLoaded(site: Site, configuration: Configuration, loc: TranslationMap) {
-        defaultPhoneCountryCode.set(site.countryCode)
-        if (phoneCountryCode.get() == null) phoneCountryCode.set(site.countryCode)
+        defaultPhoneCountryCode.set(site.countryCode.orEmpty())
+        if (phoneCountryCode.get() == null) phoneCountryCode.set(site.countryCode.orEmpty())
 
         vaccineNames.set(configuration.vaccines.map { vaccine ->
             DisplayValue(vaccine.name, loc[vaccine.name])

--- a/app/src/main/java/com/jnj/vaccinetracker/sync/domain/usecases/upload/UploadDraftVisitEncounterUseCase.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/sync/domain/usecases/upload/UploadDraftVisitEncounterUseCase.kt
@@ -6,6 +6,8 @@ import com.jnj.vaccinetracker.common.data.models.api.request.VisitUpdateRequest
 import com.jnj.vaccinetracker.common.data.models.api.response.AttributeDto
 import com.jnj.vaccinetracker.common.domain.entities.DraftState
 import com.jnj.vaccinetracker.common.domain.entities.DraftVisitEncounter
+import com.jnj.vaccinetracker.common.exceptions.WebCallException
+import com.jnj.vaccinetracker.common.helpers.logWarn
 import com.jnj.vaccinetracker.sync.data.network.VaccineTrackerSyncApiDataSource
 import javax.inject.Inject
 
@@ -29,7 +31,18 @@ class UploadDraftVisitEncounterUseCase @Inject constructor(
     suspend fun upload(draftVisitEncounter: DraftVisitEncounter) {
         require(draftVisitEncounter.draftState.isPendingUpload()) { "VisitEncounter already uploaded!" }
         val request = draftVisitEncounter.toDto()
-        api.updateVisit(request)
+        try {
+            api.updateVisit(request)
+        } catch (ex: WebCallException) {
+            if (ex.code == 404) {
+                // visit was deleted on the backend — drop this pending encounter
+                // rather than retrying forever
+                logWarn("updateVisit 404 visit not found, dropping draft encounter ${draftVisitEncounter.visitUuid}")
+                draftVisitEncounterRepository.deleteByVisitUuid(draftVisitEncounter.visitUuid)
+                return
+            }
+            throw ex
+        }
         val uploadedDraftVisitEncounter = draftVisitEncounter.copy(
             draftState = DraftState.UPLOADED)
         updateDraftStates(uploadedDraftVisitEncounter)

--- a/app/src/main/java/com/jnj/vaccinetracker/sync/domain/usecases/upload/UploadDraftVisitUseCase.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/sync/domain/usecases/upload/UploadDraftVisitUseCase.kt
@@ -1,5 +1,6 @@
 package com.jnj.vaccinetracker.sync.domain.usecases.upload
 
+import com.jnj.vaccinetracker.common.data.database.repositories.DraftVisitEncounterRepository
 import com.jnj.vaccinetracker.common.data.database.repositories.DraftVisitRepository
 import com.jnj.vaccinetracker.common.data.models.api.request.CreateVisitAttributeDto
 import com.jnj.vaccinetracker.common.data.models.api.request.VisitCreateRequest
@@ -14,6 +15,7 @@ import javax.inject.Inject
 class UploadDraftVisitUseCase @Inject constructor(
     private val api: VaccineTrackerSyncApiDataSource,
     private val draftVisitRepository: DraftVisitRepository,
+    private val draftVisitEncounterRepository: DraftVisitEncounterRepository,
 ) {
 
     private fun DraftVisit.toDto() = VisitCreateRequest(
@@ -42,9 +44,10 @@ class UploadDraftVisitUseCase @Inject constructor(
                 }
                 ex.code == 404 -> {
                     // participant no longer exists on the backend — drop this pending visit
-                    // rather than retrying forever
+                    // and any associated encounter rather than retrying forever
                     logWarn("createVisit 404 participant not found, dropping draft visit ${draftVisit.visitUuid}")
                     draftVisitRepository.deleteByVisitUuid(draftVisit.visitUuid)
+                    draftVisitEncounterRepository.deleteByVisitUuid(draftVisit.visitUuid)
                     return
                 }
                 else -> throw ex

--- a/app/src/main/java/com/jnj/vaccinetracker/sync/domain/usecases/upload/UploadDraftVisitUseCase.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/sync/domain/usecases/upload/UploadDraftVisitUseCase.kt
@@ -35,10 +35,17 @@ class UploadDraftVisitUseCase @Inject constructor(
         try {
             api.createVisit(request)
         } catch (ex: WebCallException) {
-            when (ex.cause) {
-                is DuplicateRequestException -> {
-                    // ignore exception and pretend visit was created so draft state becomes uploaded
+            when {
+                ex.cause is DuplicateRequestException -> {
+                    // ignore and treat as uploaded
                     logWarn("duplicate request exception during createVisit")
+                }
+                ex.code == 404 -> {
+                    // participant no longer exists on the backend — drop this pending visit
+                    // rather than retrying forever
+                    logWarn("createVisit 404 participant not found, dropping draft visit ${draftVisit.visitUuid}")
+                    draftVisitRepository.deleteByVisitUuid(draftVisit.visitUuid)
+                    return
                 }
                 else -> throw ex
             }


### PR DESCRIPTION
# This PR is about

-  `summary` Fix sync errors: drop stuck 404 visit pending calls, resolve participantId UNIQUE constraint on re-insert, and make site countryCode nullable 

- Drop CREATE_VISIT and UPDATE_VISIT pending calls permanently when the backend returns 404 (participant/visit not found) instead of retrying indefinitely
- Fix SQLiteConstraintException on participant re-insert by also deleting any conflicting row with the same participantId but a different UUID before inserting
- Make `Site.countryCode` nullable so a missing `country_code` field in the backend's site response no longer crashes JSON parsing with `JsonDataException`