### PR TITLE
Fix: BCG missing for unvaccinated 6-week-old children

### DIFF
--- a/app/src/main/java/com/jnj/vaccinetracker/visit/VisitViewModel.kt
+++ b/app/src/main/java/com/jnj/vaccinetracker/visit/VisitViewModel.kt
@@ -183,8 +183,13 @@ class VisitViewModel @Inject constructor(
         visitType: String
     ): List<SubstanceDataModel> {
         val byAge = SubstancesDataUtil.getSubstancesDataForCurrentVisit(birthDate, visits, configurationManager)
-        val forVisitType = byAge.filter { it.visitType == visitType }
-        if (forVisitType.isNotEmpty()) return forVisitType
+        val visitTypesOrdered = SubstancesDataUtil.getVisitTypesInOrder(configurationManager.getSubstancesConfig())
+        val currentVisitIndex = visitTypesOrdered.indexOf(visitType)
+        val forCurrentAndEarlier = byAge.filter { substance ->
+            val idx = visitTypesOrdered.indexOf(substance.visitType)
+            idx in 0..currentVisitIndex
+        }
+        if (forCurrentAndEarlier.isNotEmpty()) return forCurrentAndEarlier
         return SubstancesDataUtil.getSubstancesDataForVisitType(visitType, configurationManager)
     }
 


### PR DESCRIPTION
# Fix: BCG missing for unvaccinated 6-week-old children
- resolveSubstancesForVisit was filtering the age-based vaccine list
to only substances whose visitType exactly matched the suggested visit
type ("6 weeks"). This silently dropped BCG (visitType = "At Birth"),
which should be given as a catch-up to any unvaccinated child aged
6 weeks or older.

- The fix filters by visit-type order index instead — keeping substances
for the current visit type and any earlier ones — while still excluding
vaccines from future visit types that may appear due to overlapping age
windows.